### PR TITLE
Add cia build-target to allow for automatic CIA creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,11 +157,15 @@ endif
 .PHONY: $(BUILD) clean all
 
 #---------------------------------------------------------------------------------
-all: $(BUILD)
+all: $(BUILD) cia
 
 $(BUILD):
 	@[ -d $@ ] || mkdir -p $@
 	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
+
+#---------------------------------------------------------------------------------
+cia: $(BUILD)
+	./makerom -rsf $(OUTPUT).rsf -elf $(OUTPUT).elf -icon $(OUTPUT).icn -banner $(OUTPUT).bnr -f cia -o $(OUTPUT).cia
 
 #---------------------------------------------------------------------------------
 clean:


### PR DESCRIPTION
This trivial PR adds a new build-target to the Makefile for automatic CIA-file creation.