### PR TITLE
Fix crash on exit on ctrulib 1.2.0 when srvExit() is called without ever calling srvInit().

### DIFF
--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -1125,6 +1125,8 @@ void emulatorInitialize()
     // Do this one more time.
     if (file3dsGetCurrentDir()[0] == 0)
         file3dsInitialize();
+
+    srvInit();
 }
 
 


### PR DESCRIPTION
I'm not really sure why this happens, but this fixes it.