### PR TITLE
Improve performance of writing savestates.

### DIFF
--- a/source/bufferedfilewriter.h
+++ b/source/bufferedfilewriter.h
@@ -1,0 +1,65 @@
+#ifndef _BUFFERED_FILE_WRITER_H_
+#define _BUFFERED_FILE_WRITER_H_
+
+#include <stdio.h>
+
+class BufferedFileWriter {
+    FILE* RawFilePointer;
+    char* Buffer;
+    int Position;
+    static const int BufferSize = 1024 * 512; // 512 KB is big enough to hold all savestates I've seen.
+
+public:
+    BufferedFileWriter() : RawFilePointer(NULL), Position(0) {
+        Buffer = new char[BufferSize];
+    }
+
+    ~BufferedFileWriter() {
+        close();
+        delete[] Buffer;
+    }
+
+    bool open(const char* filename, const char* mode) {
+        RawFilePointer = fopen(filename, mode);
+        return RawFilePointer != NULL;
+    }
+
+    bool open(int fd, const char* mode) {
+        RawFilePointer = fdopen(fd, mode);
+        return RawFilePointer != NULL;
+    }
+
+    size_t write(const void* ptr, int count) {
+        if (Position + count <= BufferSize) {
+            memcpy(&Buffer[Position], ptr, count);
+            Position += count;
+        } else {
+            int space = BufferSize - Position;
+            if (space > 0) {
+                memcpy(&Buffer[Position], ptr, space);
+                Position += space;
+            }
+            flush();
+            write(((const char*)ptr) + space, count - space);
+        }
+    }
+
+    void flush() {
+        if (RawFilePointer && Position > 0) {
+            fwrite(Buffer, 1, Position, RawFilePointer);
+            Position = 0;
+        }
+    }
+
+    int close() {
+        if (RawFilePointer) {
+            flush();
+            int rv = fclose(RawFilePointer);
+            RawFilePointer = NULL;
+            return rv;
+        }
+        return -1;
+    }
+};
+
+#endif // _BUFFERED_FILE_WRITER_H_

--- a/source/snapshot.cpp
+++ b/source/snapshot.cpp
@@ -1044,7 +1044,7 @@ void FreezeStruct (BufferedFileWriter& stream, char *name, void *base, FreezeDat
 			}
 			break;
 			case uint8_ARRAY_V:
-				memmove (ptr, (uint8 *) base + fields [i].offset, fields [i].size);
+				memcpy (ptr, (uint8 *) base + fields [i].offset, fields [i].size);
 				ptr += fields [i].size;
 				break;
 			case uint16_ARRAY_V:
@@ -1146,7 +1146,7 @@ int UnfreezeStruct (STREAM stream, char *name, void *base, FreezeData *fields,
 			}
 			break;
 			case uint8_ARRAY_V:
-				memmove ((uint8 *) base + fields [i].offset, ptr, fields [i].size);
+				memcpy ((uint8 *) base + fields [i].offset, ptr, fields [i].size);
 				ptr += fields [i].size;
 				break;
 			case uint16_ARRAY_V:

--- a/source/snapshot.h
+++ b/source/snapshot.h
@@ -92,6 +92,8 @@
 #include <stdio.h>
 #include "snes9x.h"
 
+class BufferedFileWriter;
+
 #define SNAPSHOT_MAGIC "#!snes9x"
 #define SNAPSHOT_VERSION 1
 
@@ -108,7 +110,7 @@ bool8 S9xUnfreezeGame (const char *filename);
 bool8 Snapshot (const char *filename);
 bool8 S9xLoadSnapshot (const char *filename);
 bool8 S9xSPCDump (const char *filename);
-void S9xFreezeToStream (STREAM);
+void S9xFreezeToStream (BufferedFileWriter& stream);
 int S9xUnfreezeFromStream (STREAM);
 END_EXTERN_C
 


### PR DESCRIPTION
Calling `fwrite()` seems to be pretty expensive on a 3DS, so to improve savestate saving times, it's better to write the state into memory first, then flush it all at once to the SD card.

On my New 3DS and micro SD card, this reduces the time required for writing a savestate from roughly 10 seconds to roughly half a second on a SA1 game (Kirby's Dream Land 3), which is a 20x speedup! Games without state for special chips are a bit less affected because they called `fwrite()` less often. (eg.: ~7s to ~0.5s for Tetris Attack) Note that writing to a new file seems to be slightly cheaper than overwriting an existing file, for whatever reason, so the first time you save a state it's a bit faster that my given times.