### PR TITLE
Automatic save state on exit / load on start feature.

### DIFF
--- a/source/3dsimpl.cpp
+++ b/source/3dsimpl.cpp
@@ -26,6 +26,7 @@
 #include "3dsui.h"
 #include "3dsinput.h"
 #include "3dssettings.h"
+#include "3dsimpl.h"
 #include "3dsimpl_tilecache.h"
 #include "3dsimpl_gpu.h"
 
@@ -557,13 +558,22 @@ void impl3dsTouchScreenPressed()
 // name contains the slot number. This will return
 // true if the state is saved successfully.
 //---------------------------------------------------------
-bool impl3dsSaveState(int slotNumber)
+bool impl3dsSaveStateSlot(int slotNumber)
 {
 	char s[_MAX_PATH];
 	sprintf(s, ".%d.frz", slotNumber);
-	return Snapshot(S9xGetFilename (s));
+	return impl3dsSaveState(S9xGetFilename(s));
 }
 
+bool impl3dsSaveStateAuto()
+{
+	return impl3dsSaveState(S9xGetFilename(".auto.frz"));
+}
+
+bool impl3dsSaveState(const char* filename)
+{
+	return Snapshot(filename);
+}
 
 //---------------------------------------------------------
 // This is called when the user chooses to load the state.
@@ -571,11 +581,21 @@ bool impl3dsSaveState(int slotNumber)
 // name contains the slot number. This will return
 // true if the state is loaded successfully.
 //---------------------------------------------------------
-bool impl3dsLoadState(int slotNumber)
+bool impl3dsLoadStateSlot(int slotNumber)
 {
 	char s[_MAX_PATH];
 	sprintf(s, ".%d.frz", slotNumber);
-	bool success = S9xLoadSnapshot(S9xGetFilename (s));
+	return impl3dsLoadState(S9xGetFilename(s));
+}
+
+bool impl3dsLoadStateAuto()
+{
+	return impl3dsLoadState(S9xGetFilename(".auto.frz"));
+}
+
+bool impl3dsLoadState(const char* filename)
+{
+	bool success = S9xLoadSnapshot(filename);
 	if (success)
 	{
 		gpu3dsInitializeMode7Vertexes();

--- a/source/3dsimpl.h
+++ b/source/3dsimpl.h
@@ -100,15 +100,50 @@ void impl3dsTouchScreenPressed();
 // name contains the slot number. This will return
 // true if the state is saved successfully.
 //---------------------------------------------------------
-bool impl3dsSaveState(int slotNumber);
+bool impl3dsSaveStateSlot(int slotNumber);
+
+
+//---------------------------------------------------------
+// This is called when a game or the emulator is exiting
+// and the user has enabled the auto-savestate option.
+// This saves the current game's state into a game-specific
+// file whose name indicates that it's an automatic state.
+// Returns true if the state has been saved successfully.
+//---------------------------------------------------------
+bool impl3dsSaveStateAuto();
+
+
+//---------------------------------------------------------
+// Saves the current game's state to the given filename.
+// Returns true if the state has been saved successfully.
+//---------------------------------------------------------
+bool impl3dsSaveState(const char* filename);
 
 
 //---------------------------------------------------------
 // This is called when the user chooses to load the state.
-// This function should save the state into a file whose
-// name contains the slot number. This will return
-// true if the state is loaded successfully.
+// This function should load the state from the file that
+// impl3dsSaveStateSlot() saves to when called with the
+// same slotNumber.
+// Returns true if the state has been loaded successfully.
 //---------------------------------------------------------
-bool impl3dsLoadState(int slotNumber);
+bool impl3dsLoadStateSlot(int slotNumber);
+
+
+//---------------------------------------------------------
+// This is called when on game boot when the user has
+// enabled the auto-savestate option.
+// This loads the the state from the file that
+// impl3dsSaveStateAuto() saves to.
+// Returns true if the state has been saved successfully.
+//---------------------------------------------------------
+bool impl3dsLoadStateAuto();
+
+
+//---------------------------------------------------------
+// Loads the state from the given filename.
+// Returns true if the state has been loaded successfully.
+//---------------------------------------------------------
+bool impl3dsLoadState(const char* filename);
 
 #endif

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -219,6 +219,8 @@ SMenuItem optionMenu[] = {
     MENU_MAKE_PICKER    (18000, "  Font", "The font used for the user interface.", optionsForFont, DIALOGCOLOR_CYAN),
     MENU_MAKE_CHECKBOX  (15001, "  Hide text in bottom screen", 0),
     MENU_MAKE_DISABLED  (""),
+    MENU_MAKE_CHECKBOX  (19100, "  Automatically save state on exit and load state on start", 0),
+    MENU_MAKE_DISABLED  (""),
     MENU_MAKE_HEADER1   ("GAME-SPECIFIC SETTINGS"),
     MENU_MAKE_HEADER2   ("Graphics"),
     MENU_MAKE_PICKER    (10000, "  Frameskip", "Try changing this if the game runs slow. Skipping frames help it run faster but less smooth.", optionsForFrameskip, DIALOGCOLOR_CYAN),
@@ -470,6 +472,8 @@ bool settingsReadWriteFullListGlobal(bool writeMode)
     config3dsReadWriteString("Dir=%s\n", "Dir=%1000[^\n]s\n", file3dsGetCurrentDir());
     config3dsReadWriteString("ROM=%s\n", "ROM=%1000[^\n]s\n", romFileNameLastSelected);
 
+    config3dsReadWriteInt32("AutoSavestate=%d\n", &settings3DS.AutoSavestate, 0, 1);
+
     // All new options should come here!
 
     config3dsCloseFile();
@@ -575,6 +579,9 @@ void emulatorLoadRom()
     settingsUpdateAllSettings();
     menuSetupCheats();
 
+    if (settings3DS.AutoSavestate)
+        impl3dsLoadStateAuto();
+
     snd3DS.generateSilence = false;
 }
 
@@ -654,6 +661,7 @@ bool menuCopySettings(bool copyMenuToSettings)
     UPDATE_SETTINGS(settings3DS.Turbo[5], 1, 13005);
     UPDATE_SETTINGS(settings3DS.Volume, 1, 14000);
     UPDATE_SETTINGS(settings3DS.PaletteFix, 1, 16000);
+    UPDATE_SETTINGS(settings3DS.AutoSavestate, 1, 19100);
     UPDATE_SETTINGS(settings3DS.SRAMSaveInterval, 1, 17000);
 
     return settingsUpdated;
@@ -874,9 +882,32 @@ void menuPause()
             }
             else
             {
-                strncpy(romFileNameLastSelected, romFileName, _MAX_PATH);
-                loadRomBeforeExit = true;
-                break;
+                bool loadRom = true;
+
+                // in case someone changed the AutoSavestate option while the menu was open
+                if (menuCopySettings(true))
+                    settingsSave();
+
+                if (settings3DS.AutoSavestate)
+                {
+                    menu3dsShowDialog("Save State", "Autosaving...", DIALOGCOLOR_CYAN, NULL, 0);
+                    bool result = impl3dsSaveStateAuto();
+                    menu3dsHideDialog();
+
+                    if (!result)
+                    {
+                        int choice = menu3dsShowDialog("Autosave failure", "Automatic savestate writing failed.\nLoad chosen game anyway?", DIALOGCOLOR_RED, optionsForNoYes, sizeof(optionsForNoYes) / sizeof(SMenuItem));
+                        if (choice != 1)
+                            loadRom = false;
+                    }
+                }
+
+                if (loadRom)
+                {
+                    strncpy(romFileNameLastSelected, romFileName, _MAX_PATH);
+                    loadRomBeforeExit = true;
+                    break;
+                }
             }
         }
         else if (selection >= 2001 && selection <= 2010)
@@ -886,7 +917,7 @@ void menuPause()
            
             sprintf(text, "Saving into slot %d...\nThis may take a while", slot);
             menu3dsShowDialog("Savestates", text, DIALOGCOLOR_CYAN, NULL, 0);
-            bool result = impl3dsSaveState(slot);
+            bool result = impl3dsSaveStateSlot(slot);
             menu3dsHideDialog();
 
             if (result)
@@ -909,7 +940,7 @@ void menuPause()
             int slot = selection - 3000;
             char text[200];
 
-            bool result = impl3dsLoadState(slot);
+            bool result = impl3dsLoadStateSlot(slot);
             if (result)
             {
                 GPU3DS.emulatorState = EMUSTATE_EMULATE;
@@ -1398,6 +1429,9 @@ int main()
     }
 
 quit:
+    if (GPU3DS.emulatorState > 0 && settings3DS.AutoSavestate)
+        impl3dsSaveStateAuto();
+
     printf("emulatorFinalize:\n");
     emulatorFinalize();
     printf ("Exiting...\n");

--- a/source/3dssettings.h
+++ b/source/3dssettings.h
@@ -34,6 +34,11 @@ typedef struct
                                             //   2 - Disabled - Style 1.
                                             //   3 - Disabled - Style 2.
 
+    int     AutoSavestate = 0;              // Automatically save the the current state when the emulator is closed
+                                            // or the game is changed, and load it again when the game is loaded.
+                                            //   0 - Disabled
+                                            //   1 - Enabled
+
     int     SRAMSaveInterval;               // SRAM Save Interval
                                             //   1 - 1 second.
                                             //   2 - 10 seconds


### PR DESCRIPTION
This adds an option that saves the game's state when exiting the emulator or changing game, and loads it again when starting the game again. Basically a quick suspend to exit the emulator, do something else for a while, then come back and continue right where you left off without having to manually save and load state.