### PR TITLE
Respect the Force SRAM Write On Pause option when the system is suspended.

### DIFF
--- a/source/3dsexit.cpp
+++ b/source/3dsexit.cpp
@@ -3,6 +3,7 @@
 
 #include "3dsexit.h"
 #include "3dsgpu.h"
+#include "3dssettings.h"
 #include "3dssound.h"
 #include "memmap.h"
 #include "snes9x.h"
@@ -10,6 +11,8 @@
 aptHookCookie hookCookie;
 int appExiting = 0;
 int appSuspended = 0;
+
+extern S9xSettings3DS settings3DS;
 
 void handleAptHook(APT_HookType hook, void* param)
 {
@@ -22,7 +25,7 @@ void handleAptHook(APT_HookType hook, void* param)
             appSuspended = 1;
             if (GPU3DS.emulatorState == EMUSTATE_EMULATE) {
                 snd3dsStopPlaying();
-                if (CPU.SRAMModified || CPU.AutoSaveTimer) {
+                if (settings3DS.ForceSRAMWriteOnPause || CPU.SRAMModified || CPU.AutoSaveTimer) {
                     S9xAutoSaveSRAM();
                 }
             }


### PR DESCRIPTION
This is needed to make #26 work when hitting the Home button to suspend the emulator (and possibly closing it afterwards).