### PR TITLE
Menu refactoring.

### DIFF
--- a/source/3dsfiles.cpp
+++ b/source/3dsfiles.cpp
@@ -142,12 +142,12 @@ char* stristr( char* str1, const char* str2 )
 }
 
 //----------------------------------------------------------------------
-// Load all ROM file names (up to 512 ROMs)
+// Load all ROM file names
 //
 // Specify a comma separated list of extensions.
 //
 //----------------------------------------------------------------------
-void file3dsGetFiles(std::vector<DirectoryEntry>& files, char *extensions, int maxFiles)
+void file3dsGetFiles(std::vector<DirectoryEntry>& files, char *extensions)
 {
     files.clear();
 

--- a/source/3dsfiles.h
+++ b/source/3dsfiles.h
@@ -46,11 +46,8 @@ void file3dsGoToChildDirectory(const char* childDir);
 
 
 //----------------------------------------------------------------------
-// Load all ROM file names
-//
-// Specify a comma separated list of extensions.
-//
+// Fetch all file names with any of the given extensions
 //----------------------------------------------------------------------
-void file3dsGetFiles(std::vector<DirectoryEntry>& files, char *extensions);
+void file3dsGetFiles(std::vector<DirectoryEntry>& files, const std::vector<std::string>& extensions);
 
 #endif

--- a/source/3dsfiles.h
+++ b/source/3dsfiles.h
@@ -5,6 +5,16 @@
 #include <string>
 #include <vector>
 
+enum class FileEntryType { ParentDirectory, ChildDirectory, File };
+
+struct DirectoryEntry {
+    std::string Filename;
+    FileEntryType Type;
+
+    DirectoryEntry(const std::string& filename, FileEntryType type)
+    : Filename(filename), Type(type) { }
+};
+
 //----------------------------------------------------------------------
 // Initialize the library
 //----------------------------------------------------------------------
@@ -18,6 +28,12 @@ char *file3dsGetCurrentDir(void);
 
 
 //----------------------------------------------------------------------
+// Go up or down a level.
+//----------------------------------------------------------------------
+void file3dsGoUpOrDownDirectory(const DirectoryEntry& entry);
+
+
+//----------------------------------------------------------------------
 // Go up to the parent directory.
 //----------------------------------------------------------------------
 void file3dsGoToParentDirectory(void);
@@ -26,7 +42,7 @@ void file3dsGoToParentDirectory(void);
 //----------------------------------------------------------------------
 // Go up to the child directory.
 //----------------------------------------------------------------------
-void file3dsGoToChildDirectory(char *childDir);
+void file3dsGoToChildDirectory(const char* childDir);
 
 
 //----------------------------------------------------------------------
@@ -35,6 +51,6 @@ void file3dsGoToChildDirectory(char *childDir);
 // Specify a comma separated list of extensions.
 //
 //----------------------------------------------------------------------
-std::vector<std::string> file3dsGetFiles(char *extensions, int maxFiles);
+void file3dsGetFiles(std::vector<DirectoryEntry>& files, char *extensions, int maxFiles);
 
 #endif

--- a/source/3dsfiles.h
+++ b/source/3dsfiles.h
@@ -46,11 +46,11 @@ void file3dsGoToChildDirectory(const char* childDir);
 
 
 //----------------------------------------------------------------------
-// Load all ROM file names (up to 512 ROMs)
+// Load all ROM file names
 //
 // Specify a comma separated list of extensions.
 //
 //----------------------------------------------------------------------
-void file3dsGetFiles(std::vector<DirectoryEntry>& files, char *extensions, int maxFiles);
+void file3dsGetFiles(std::vector<DirectoryEntry>& files, char *extensions);
 
 #endif

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -128,10 +128,10 @@ namespace {
 }
 
 #define MENU_MAKE_ACTION(ID, text, callback) \
-    items.emplace_back( callback, MenuItemType::Action, ID, text, ""s, 0 )
+    items.emplace_back( callback, MenuItemType::Action, ID, text, ""s, ID )
 
 #define MENU_MAKE_DIALOG_ACTION(ID, text, desc) \
-    items.emplace_back( nullptr, MenuItemType::Action, ID, text, desc, 0 )
+    items.emplace_back( nullptr, MenuItemType::Action, ID, text, desc, ID )
 
 #define MENU_MAKE_DISABLED(text) \
     items.emplace_back( nullptr, MenuItemType::Disabled, -1, text, ""s )

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -137,6 +137,19 @@ namespace {
 #define MENU_MAKE_PICKER(ID, text, pickerDescription, pickerOptions, value, backColor, callback) \
     items.emplace_back( callback, MenuItemType::Picker, ID, text, ""s, value, 0, 0, pickerDescription, pickerOptions, backColor )
 
+void exitEmulatorOptionSelected( int val ) {
+    if ( val == 1 ) {
+        GPU3DS.emulatorState = EMUSTATE_END;
+        appExiting = 1;
+    }
+}
+
+std::vector<SMenuItem> makeOptionsForNoYes() {
+    std::vector<SMenuItem> items;
+    MENU_MAKE_ACTION(0, "No"s, nullptr);
+    MENU_MAKE_ACTION(1, "Yes"s, nullptr);
+    return items;
+}
 
 std::vector<SMenuItem> makeEmulatorMenu() {
     std::vector<SMenuItem> items;
@@ -160,7 +173,7 @@ std::vector<SMenuItem> makeEmulatorMenu() {
     MENU_MAKE_HEADER2   ("Others"s);
     MENU_MAKE_ACTION    (4001, "  Take Screenshot"s, nullptr); // TODO!
     MENU_MAKE_ACTION    (5001, "  Reset Console"s, nullptr); // TODO!
-    MENU_MAKE_ACTION    (6001, "  Exit"s, nullptr); // TODO!
+    MENU_MAKE_PICKER    (6001, "  Exit"s, "Leaving so soon?", makeOptionsForNoYes(), 0, DIALOGCOLOR_RED, exitEmulatorOptionSelected);
     return items;
 }
 
@@ -222,7 +235,7 @@ std::vector<SMenuItem> makeOptionsForInFramePaletteChanges() {
 
 std::vector<SMenuItem> makeEmulatorNewMenu() {
     std::vector<SMenuItem> items;
-    MENU_MAKE_ACTION(6001, "  Exit"s, nullptr); // TODO!
+    MENU_MAKE_PICKER(6001, "  Exit"s, "Leaving so soon?", makeOptionsForNoYes(), 0, DIALOGCOLOR_RED, exitEmulatorOptionSelected);
     return items;
 }
 
@@ -276,13 +289,6 @@ std::vector<SMenuItem> makeCheatMenu() {
     menuSetupCheats(items);
     return items;
 };
-
-std::vector<SMenuItem> makeOptionsForNoYes() {
-    std::vector<SMenuItem> items;
-    MENU_MAKE_ACTION(0, "No"s, nullptr);
-    MENU_MAKE_ACTION(1, "Yes"s, nullptr);
-    return items;
-}
 
 std::vector<SMenuItem> makeOptionsForOk() {
     std::vector<SMenuItem> items;
@@ -737,17 +743,6 @@ void menuSelectFile(void)
                 return;
             }
         }
-        else if (selection == 6001)
-        {
-            int result = menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Exit",  "Leaving so soon?", DIALOGCOLOR_RED, makeOptionsForNoYes());
-            menu3dsHideDialog(dialogTab, isDialog, currentMenuTab, menuTab);
-
-            if (result == 1)
-            {
-                GPU3DS.emulatorState = EMUSTATE_END;
-                return;
-            }
-        }
 
         selection = -1;     // Bug fix: Fixes crashing when setting options before any ROMs are loaded.
     }
@@ -992,20 +987,6 @@ void menuPause()
             }
             
         }
-        else if (selection == 6001)
-        {
-            int result = menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Exit",  "Leaving so soon?", DIALOGCOLOR_RED, makeOptionsForNoYes());
-            if (result == 1)
-            {
-                GPU3DS.emulatorState = EMUSTATE_END;
-
-                break;
-            }
-            else
-                menu3dsHideDialog(dialogTab, isDialog, currentMenuTab, menuTab);
-            
-        }
-
     }
 
     menu3dsHideMenu(dialogTab, isDialog, currentMenuTab, menuTab);

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -128,28 +128,28 @@ namespace {
 }
 
 #define MENU_MAKE_ACTION(ID, text, callback) \
-    items.emplace_back( callback, MenuItemType::Action, ID, text, ""s, ID )
+    items.emplace_back( callback, MenuItemType::Action, text, ""s, 0 )
 
-#define MENU_MAKE_DIALOG_ACTION(ID, text, desc) \
-    items.emplace_back( nullptr, MenuItemType::Action, ID, text, desc, ID )
+#define MENU_MAKE_DIALOG_ACTION(value, text, desc) \
+    items.emplace_back( nullptr, MenuItemType::Action, text, desc, value )
 
 #define MENU_MAKE_DISABLED(text) \
-    items.emplace_back( nullptr, MenuItemType::Disabled, -1, text, ""s )
+    items.emplace_back( nullptr, MenuItemType::Disabled, text, ""s )
 
 #define MENU_MAKE_HEADER1(text) \
-    items.emplace_back( nullptr, MenuItemType::Header1, -1, text, ""s )
+    items.emplace_back( nullptr, MenuItemType::Header1, text, ""s )
 
 #define MENU_MAKE_HEADER2(text) \
-    items.emplace_back( nullptr, MenuItemType::Header2, -1, text, ""s )
+    items.emplace_back( nullptr, MenuItemType::Header2, text, ""s )
 
 #define MENU_MAKE_CHECKBOX(ID, text, value, callback) \
-    items.emplace_back( callback, MenuItemType::Checkbox, ID, text, ""s, value )
+    items.emplace_back( callback, MenuItemType::Checkbox, text, ""s, value )
 
 #define MENU_MAKE_GAUGE(ID, text, min, max, value, callback) \
-    items.emplace_back( callback, MenuItemType::Gauge, ID, text, ""s, value, min, max )
+    items.emplace_back( callback, MenuItemType::Gauge, text, ""s, value, min, max )
 
 #define MENU_MAKE_PICKER(ID, text, pickerDescription, pickerOptions, value, backColor, callback) \
-    items.emplace_back( callback, MenuItemType::Picker, ID, text, ""s, value, 0, 0, pickerDescription, pickerOptions, backColor )
+    items.emplace_back( callback, MenuItemType::Picker, text, ""s, value, 0, 0, pickerDescription, pickerOptions, backColor )
 
 void exitEmulatorOptionSelected( int val ) {
     if ( val == 1 ) {
@@ -160,14 +160,14 @@ void exitEmulatorOptionSelected( int val ) {
 
 std::vector<SMenuItem> makeOptionsForNoYes() {
     std::vector<SMenuItem> items;
-    MENU_MAKE_ACTION(0, "No"s, nullptr);
-    MENU_MAKE_ACTION(1, "Yes"s, nullptr);
+    MENU_MAKE_DIALOG_ACTION(0, "No"s, ""s);
+    MENU_MAKE_DIALOG_ACTION(1, "Yes"s, ""s);
     return items;
 }
 
 std::vector<SMenuItem> makeOptionsForOk() {
     std::vector<SMenuItem> items;
-    MENU_MAKE_ACTION(0, "OK"s, nullptr);
+    MENU_MAKE_DIALOG_ACTION(0, "OK"s, ""s);
     return items;
 }
 
@@ -176,7 +176,7 @@ std::vector<SMenuItem> makeEmulatorMenu(std::vector<SMenuTab>& menuTab, int& cur
     MENU_MAKE_HEADER2   ("Resume"s);
     items.emplace_back([&closeMenu](int val) {
         closeMenu = true;
-    }, MenuItemType::Action, 1000, "  Resume Game"s, ""s, 0);
+    }, MenuItemType::Action, "  Resume Game"s, ""s, 0);
     MENU_MAKE_HEADER2   (""s);
 
     MENU_MAKE_HEADER2   ("Savestates"s);
@@ -202,7 +202,7 @@ std::vector<SMenuItem> makeEmulatorMenu(std::vector<SMenuTab>& menuTab, int& cur
                 menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Savestate failure", oss.str(), DIALOGCOLOR_RED, makeOptionsForOk());
                 menu3dsHideDialog(dialogTab, isDialog, currentMenuTab, menuTab);
             }
-        }, MenuItemType::Action, 2000 + slot, optionText.str(), ""s, 0);
+        }, MenuItemType::Action, optionText.str(), ""s, 0);
     }
     MENU_MAKE_HEADER2   (""s);
     
@@ -221,7 +221,7 @@ std::vector<SMenuItem> makeEmulatorMenu(std::vector<SMenuTab>& menuTab, int& cur
             } else {
                 closeMenu = true;
             }
-        }, MenuItemType::Action, 3000 + slot, optionText.str(), ""s, 0);
+        }, MenuItemType::Action, optionText.str(), ""s, 0);
     }
     MENU_MAKE_HEADER2   (""s);
 
@@ -268,7 +268,7 @@ std::vector<SMenuItem> makeEmulatorMenu(std::vector<SMenuTab>& menuTab, int& cur
             menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Screenshot", "Oops. Unable to take screenshot!", DIALOGCOLOR_RED, makeOptionsForOk());
             menu3dsHideDialog(dialogTab, isDialog, currentMenuTab, menuTab);
         }
-    }, MenuItemType::Action, 4001, "  Take Screenshot"s, ""s, 0);
+    }, MenuItemType::Action, "  Take Screenshot"s, ""s, 0);
 
     items.emplace_back([&menuTab, &currentMenuTab, &closeMenu](int val) {
         SMenuTab dialogTab;
@@ -280,7 +280,7 @@ std::vector<SMenuItem> makeEmulatorMenu(std::vector<SMenuTab>& menuTab, int& cur
             impl3dsResetConsole();
             closeMenu = true;
         }
-    }, MenuItemType::Action, 5001, "  Reset Console"s, ""s, 0);
+    }, MenuItemType::Action, "  Reset Console"s, ""s, 0);
 
     MENU_MAKE_PICKER    (6001, "  Exit"s, "Leaving so soon?", makeOptionsForNoYes(), 0, DIALOGCOLOR_RED, exitEmulatorOptionSelected);
 
@@ -749,7 +749,6 @@ bool menuCopyCheats(std::vector<SMenuItem>& cheatMenu, bool copyMenuToSettings)
     for (int i = 0; (i+1) < cheatMenu.size() && i < MAX_CHEATS && i < Cheat.num_cheats; i++)
     {
         cheatMenu[i+1].Type = MenuItemType::Checkbox;
-        cheatMenu[i+1].ID = 20000 + i;
         cheatMenu[i+1].Text = Cheat.c[i].name;
 
         if (copyMenuToSettings)
@@ -780,7 +779,7 @@ void fillFileMenuFromFileNames(std::vector<SMenuItem>& fileMenu, const std::vect
         const DirectoryEntry& entry = romFileNames[i];
         fileMenu.emplace_back( [&entry, &selectedEntry]( int val ) {
             selectedEntry = &entry;
-        }, MenuItemType::Action, i, std::string( entry.Filename ), ""s );
+        }, MenuItemType::Action, entry.Filename, ""s );
     }
 }
 
@@ -995,14 +994,14 @@ void menuSetupCheats(std::vector<SMenuItem>& cheatMenu)
     {
         for (int i = 0; i < MAX_CHEATS && i < Cheat.num_cheats; i++)
         {
-            cheatMenu.emplace_back(nullptr, MenuItemType::Checkbox, 20000+i, std::string(Cheat.c[i].name), ""s, Cheat.c[i].enabled ? 1 : 0);
+            cheatMenu.emplace_back(nullptr, MenuItemType::Checkbox, std::string(Cheat.c[i].name), ""s, Cheat.c[i].enabled ? 1 : 0);
         }
     }
     else
     {
         for (int i = 0; i < 14; i++)
         {
-            cheatMenu.emplace_back(nullptr, MenuItemType::Disabled, -2, std::string(noCheatsText[i]), ""s);
+            cheatMenu.emplace_back(nullptr, MenuItemType::Disabled, std::string(noCheatsText[i]), ""s);
         }
     }
 }

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -729,12 +729,11 @@ void emulatorLoadRom()
 
 
 //----------------------------------------------------------------------
-// Load all ROM file names (up to 1000 ROMs)
+// Load all ROM file names
 //----------------------------------------------------------------------
 void fileGetAllFiles(std::vector<DirectoryEntry>& romFileNames)
 {
-    // TODO: Lift the 1k file limitation once we no longer have hardcoded IDs for menu items.
-    file3dsGetFiles(romFileNames, "smc,sfc,fig", 1000);
+    file3dsGetFiles(romFileNames, "smc,sfc,fig");
 }
 
 

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -3,6 +3,7 @@
 #include <cstring>
 #include <cstdlib>
 #include <ctime>
+#include <string>
 #include <vector>
 
 #include <unistd.h>
@@ -37,6 +38,10 @@
 #include "3dsimpl_gpu.h"
 
 #include "lodepng.h"
+
+inline std::string operator "" s(const char* s, unsigned int length) {
+    return std::string(s, length);
+}
 
 S9xSettings3DS settings3DS;
 
@@ -98,181 +103,171 @@ void clearTopScreenWithLogo()
 //----------------------------------------------------------------------
 
 #define MENU_MAKE_ACTION(ID, text) \
-    { MENUITEM_ACTION, ID, text, NULL, 0 }
+    items.emplace_back( MENUITEM_ACTION, ID, text, ""s, 0 )
 
 #define MENU_MAKE_DIALOG_ACTION(ID, text, desc) \
-    { MENUITEM_ACTION, ID, text, desc, 0 }
+    items.emplace_back( MENUITEM_ACTION, ID, text, desc, 0 )
 
 #define MENU_MAKE_DISABLED(text) \
-    { MENUITEM_DISABLED, -1, text, NULL }
+    items.emplace_back( MENUITEM_DISABLED, -1, text, ""s )
 
 #define MENU_MAKE_HEADER1(text) \
-    { MENUITEM_HEADER1, -1, text, NULL }
+    items.emplace_back( MENUITEM_HEADER1, -1, text, ""s )
 
 #define MENU_MAKE_HEADER2(text) \
-    { MENUITEM_HEADER2, -1, text, NULL }
+    items.emplace_back( MENUITEM_HEADER2, -1, text, ""s )
 
 #define MENU_MAKE_CHECKBOX(ID, text, value) \
-    { MENUITEM_CHECKBOX, ID, text, NULL, value }
+    items.emplace_back( MENUITEM_CHECKBOX, ID, text, ""s, value )
 
 #define MENU_MAKE_GAUGE(ID, text, min, max, value) \
-    { MENUITEM_GAUGE, ID, text, NULL, value, min, max }
+    items.emplace_back( MENUITEM_GAUGE, ID, text, ""s, value, min, max )
 
 #define MENU_MAKE_PICKER(ID, text, pickerDescription, pickerOptions, backColor) \
-    { MENUITEM_PICKER, ID, text, NULL, 0, 0, 0, pickerDescription, sizeof(pickerOptions)/sizeof(SMenuItem), pickerOptions, backColor }
+    items.emplace_back( MENUITEM_PICKER, ID, text, ""s, 0, 0, 0, pickerDescription, pickerOptions, backColor )
 
 
-SMenuItem emulatorMenu[] = {
-    MENU_MAKE_HEADER2   ("Resume"),
-    MENU_MAKE_ACTION    (1000, "  Resume Game"),
-    MENU_MAKE_HEADER2   (""),
+std::vector<SMenuItem> makeEmulatorMenu() {
+    std::vector<SMenuItem> items;
+    MENU_MAKE_HEADER2   ("Resume"s);
+    MENU_MAKE_ACTION    (1000, "  Resume Game"s);
+    MENU_MAKE_HEADER2   (""s);
 
-    MENU_MAKE_HEADER2   ("Savestates"),
-    MENU_MAKE_ACTION    (2001, "  Save Slot #1"),
-    MENU_MAKE_ACTION    (2002, "  Save Slot #2"),
-    MENU_MAKE_ACTION    (2003, "  Save Slot #3"),
-    MENU_MAKE_ACTION    (2004, "  Save Slot #4"),
-    MENU_MAKE_HEADER2   (""),
+    MENU_MAKE_HEADER2   ("Savestates"s);
+    MENU_MAKE_ACTION    (2001, "  Save Slot #1"s);
+    MENU_MAKE_ACTION    (2002, "  Save Slot #2"s);
+    MENU_MAKE_ACTION    (2003, "  Save Slot #3"s);
+    MENU_MAKE_ACTION    (2004, "  Save Slot #4"s);
+    MENU_MAKE_HEADER2   (""s);
     
-    MENU_MAKE_ACTION    (3001, "  Load Slot #1"),
-    MENU_MAKE_ACTION    (3002, "  Load Slot #2"),
-    MENU_MAKE_ACTION    (3003, "  Load Slot #3"),
-    MENU_MAKE_ACTION    (3004, "  Load Slot #4"),
-    MENU_MAKE_HEADER2   (""),
+    MENU_MAKE_ACTION    (3001, "  Load Slot #1"s);
+    MENU_MAKE_ACTION    (3002, "  Load Slot #2"s);
+    MENU_MAKE_ACTION    (3003, "  Load Slot #3"s);
+    MENU_MAKE_ACTION    (3004, "  Load Slot #4"s);
+    MENU_MAKE_HEADER2   (""s);
 
-    MENU_MAKE_HEADER2   ("Others"),
-    MENU_MAKE_ACTION    (4001, "  Take Screenshot"),
-    MENU_MAKE_ACTION    (5001, "  Reset Console"),
-    MENU_MAKE_ACTION    (6001, "  Exit"),
-    /*
-    { -1         ,   "Resume           ", -1, 0, 0, 0 },
-    { 1000,          "  Resume Game    ", -1, 0, 0, 0 },
-    { -1         ,   NULL,                -1, 0, 0, 0 },
-    { -1         ,   "Savestates       ", -1, 0, 0, 0 },
-    { 2001,          "  Save Slot #1   ", -1, 0, 0, 0 },
-    { 2002,          "  Save Slot #2   ", -1, 0, 0, 0 },
-    { 2003,          "  Save Slot #3   ", -1, 0, 0, 0 },
-    { 2004,          "  Save Slot #4   ", -1, 0, 0, 0 },
-    { -1         ,   NULL,                -1, 0, 0, 0 },
-    { 3001,          "  Load Slot #1   ", -1, 0, 0, 0 },
-    { 3002,          "  Load Slot #2   ", -1, 0, 0, 0 },
-    { 3003,          "  Load Slot #3   ", -1, 0, 0, 0 },
-    { 3004,          "  Load Slot #4   ", -1, 0, 0, 0 },
-    { -1         ,   NULL,                -1, 0, 0, 0 },
-    { -1         ,   "Emulation        ", -1, 0, 0, 0 },
-    { 4001,          "  Take Screenshot", -1, 0, 0, 0 },
-    { 5001,          "  Reset Console  ", -1, 0, 0, 0 },
-    { 6001,          "  Exit           ", -1, 0, 0, 0 }*/
-    };
+    MENU_MAKE_HEADER2   ("Others"s);
+    MENU_MAKE_ACTION    (4001, "  Take Screenshot"s);
+    MENU_MAKE_ACTION    (5001, "  Reset Console"s);
+    MENU_MAKE_ACTION    (6001, "  Exit"s);
+    return items;
+}
 
-SMenuItem optionsForFont[] = {
-    MENU_MAKE_DIALOG_ACTION (0, "Tempesta",               ""),
-    MENU_MAKE_DIALOG_ACTION (1, "Ronda",               ""),
-    MENU_MAKE_DIALOG_ACTION (2, "Arial",                  "")
+std::vector<SMenuItem> makeOptionsForFont() {
+    std::vector<SMenuItem> items;
+    MENU_MAKE_DIALOG_ACTION (0, "Tempesta"s,              ""s);
+    MENU_MAKE_DIALOG_ACTION (1, "Ronda"s,              ""s);
+    MENU_MAKE_DIALOG_ACTION (2, "Arial"s,                 ""s);
+    return items;
+}
+
+std::vector<SMenuItem> makeOptionsForStretch() {
+    std::vector<SMenuItem> items;
+    MENU_MAKE_DIALOG_ACTION (0, "No Stretch"s,              "'Pixel Perfect'"s);
+    MENU_MAKE_DIALOG_ACTION (7, "Expand to Fit"s,           "'Pixel Perfect' fit"s);
+    MENU_MAKE_DIALOG_ACTION (6, "TV-style"s,                "Stretch width only to 292px"s);
+    MENU_MAKE_DIALOG_ACTION (5, "4:3"s,                     "Stretch width only"s);
+    MENU_MAKE_DIALOG_ACTION (1, "4:3 Fit"s,                 "Stretch to 320x240"s);
+    MENU_MAKE_DIALOG_ACTION (2, "Fullscreen"s,              "Stretch to 400x240"s);
+    MENU_MAKE_DIALOG_ACTION (3, "Cropped 4:3 Fit"s,         "Crop & Stretch to 320x240"s);
+    MENU_MAKE_DIALOG_ACTION (4, "Cropped Fullscreen"s,      "Crop & Stretch to 400x240"s);
+    return items;
+}
+
+std::vector<SMenuItem> makeOptionsForFrameskip() {
+    std::vector<SMenuItem> items;
+    MENU_MAKE_DIALOG_ACTION (0, "Disabled"s,                ""s);
+    MENU_MAKE_DIALOG_ACTION (1, "Enabled (max 1 frame)"s,   ""s);
+    MENU_MAKE_DIALOG_ACTION (2, "Enabled (max 2 frames)"s,   ""s);
+    MENU_MAKE_DIALOG_ACTION (3, "Enabled (max 3 frames)"s,   ""s);
+    MENU_MAKE_DIALOG_ACTION (4, "Enabled (max 4 frames)"s,   ""s);
+    return items;
 };
 
-SMenuItem optionsForStretch[] = {
-    MENU_MAKE_DIALOG_ACTION (0, "No Stretch",               "'Pixel Perfect'"),
-    MENU_MAKE_DIALOG_ACTION (7, "Expand to Fit",            "'Pixel Perfect' fit"),
-    MENU_MAKE_DIALOG_ACTION (6, "TV-style",                 "Stretch width only to 292px"),
-    MENU_MAKE_DIALOG_ACTION (5, "4:3",                      "Stretch width only"),
-    MENU_MAKE_DIALOG_ACTION (1, "4:3 Fit",                  "Stretch to 320x240"),
-    MENU_MAKE_DIALOG_ACTION (2, "Fullscreen",               "Stretch to 400x240"),
-    MENU_MAKE_DIALOG_ACTION (3, "Cropped 4:3 Fit",          "Crop & Stretch to 320x240"),
-    MENU_MAKE_DIALOG_ACTION (4, "Cropped Fullscreen",       "Crop & Stretch to 400x240")
+std::vector<SMenuItem> makeOptionsForFrameRate() {
+    std::vector<SMenuItem> items;
+    MENU_MAKE_DIALOG_ACTION (0, "Default based on ROM region"s,    ""s);
+    MENU_MAKE_DIALOG_ACTION (1, "50 FPS"s,                  ""s);
+    MENU_MAKE_DIALOG_ACTION (2, "60 FPS"s,                  ""s);
+    return items;
 };
 
-SMenuItem optionsForFrameskip[] = {
-    MENU_MAKE_DIALOG_ACTION (0, "Disabled",                 ""),
-    MENU_MAKE_DIALOG_ACTION (1, "Enabled (max 1 frame)",    ""),
-    MENU_MAKE_DIALOG_ACTION (2, "Enabled (max 2 frames)",    ""),
-    MENU_MAKE_DIALOG_ACTION (3, "Enabled (max 3 frames)",    ""),
-    MENU_MAKE_DIALOG_ACTION (4, "Enabled (max 4 frames)",    "")
+std::vector<SMenuItem> makeOptionsForAutoSaveSRAMDelay() {
+    std::vector<SMenuItem> items;
+    MENU_MAKE_DIALOG_ACTION (1, "1 second"s,    ""s);
+    MENU_MAKE_DIALOG_ACTION (2, "10 seconds"s,  ""s);
+    MENU_MAKE_DIALOG_ACTION (3, "60 seconds"s,  ""s);
+    MENU_MAKE_DIALOG_ACTION (4, "Disabled"s,    "Touch bottom screen to save"s);
+    return items;
 };
 
-SMenuItem optionsForFrameRate[] = {
-    MENU_MAKE_DIALOG_ACTION (0, "Default based on ROM region",     ""),
-    MENU_MAKE_DIALOG_ACTION (1, "50 FPS",                   ""),
-    MENU_MAKE_DIALOG_ACTION (2, "60 FPS",                   "")
+std::vector<SMenuItem> makeOptionsForInFramePaletteChanges() {
+    std::vector<SMenuItem> items;
+    MENU_MAKE_DIALOG_ACTION (1, "Enabled"s,         "Best (not 100% accurate); slower"s);
+    MENU_MAKE_DIALOG_ACTION (2, "Disabled Style 1"s,"Faster than \"Enabled\""s);
+    MENU_MAKE_DIALOG_ACTION (3, "Disabled Style 2"s,"Faster than \"Enabled\""s);
+    return items;
 };
 
-SMenuItem optionsForAutoSaveSRAMDelay[] = {
-    MENU_MAKE_DIALOG_ACTION (1, "1 second",     ""),
-    MENU_MAKE_DIALOG_ACTION (2, "10 seconds",   ""),
-    MENU_MAKE_DIALOG_ACTION (3, "60 seconds",   ""),
-    MENU_MAKE_DIALOG_ACTION (4, "Disabled",     "Touch bottom screen to save")
+std::vector<SMenuItem> makeEmulatorNewMenu() {
+    std::vector<SMenuItem> items;
+    MENU_MAKE_ACTION(6001, "  Exit"s);
+    return items;
+}
+
+std::vector<SMenuItem> makeOptionMenu() {
+    std::vector<SMenuItem> items;
+    MENU_MAKE_HEADER1   ("GLOBAL SETTINGS"s);
+    MENU_MAKE_PICKER    (11000, "  Screen Stretch"s,"How would you like the final screen to appear?"s,makeOptionsForStretch(), DIALOGCOLOR_CYAN);
+    MENU_MAKE_PICKER    (18000, "  Font"s,"The font used for the user interface."s,makeOptionsForFont(), DIALOGCOLOR_CYAN);
+    MENU_MAKE_CHECKBOX  (15001, "  Hide text in bottom screen"s,0);
+    MENU_MAKE_DISABLED  (""s);
+    MENU_MAKE_CHECKBOX  (19100, "  Automatically save state on exit and load state on start"s,0);
+    MENU_MAKE_DISABLED  (""s);
+    MENU_MAKE_HEADER1   ("GAME-SPECIFIC SETTINGS"s);
+    MENU_MAKE_HEADER2   ("Graphics"s);
+    MENU_MAKE_PICKER    (10000, "  Frameskip"s,"Try changing this if the game runs slow. Skipping frames help it run faster but less smooth."s,makeOptionsForFrameskip(), DIALOGCOLOR_CYAN);
+    MENU_MAKE_PICKER    (12000, "  Framerate"s,"Some games run at 50 or 60 FPS by default. Override if required."s,makeOptionsForFrameRate(), DIALOGCOLOR_CYAN);
+    MENU_MAKE_PICKER    (16000, "  In-Frame Palette Changes"s,"Try changing this if some colours in the game look off."s,makeOptionsForInFramePaletteChanges(), DIALOGCOLOR_CYAN);
+    MENU_MAKE_DISABLED  (""s);
+    MENU_MAKE_HEADER2   ("Audio"s);
+    MENU_MAKE_GAUGE     (14000, "  Volume Amplification"s,0, 8, 4);
+    MENU_MAKE_DISABLED  (""s);
+    MENU_MAKE_HEADER2   ("Turbo (Auto-Fire) Buttons"s);
+    MENU_MAKE_CHECKBOX  (13000, "  Button A"s,0);
+    MENU_MAKE_CHECKBOX  (13001, "  Button B"s,0);
+    MENU_MAKE_CHECKBOX  (13002, "  Button X"s,0);
+    MENU_MAKE_CHECKBOX  (13003, "  Button Y"s,0);
+    MENU_MAKE_CHECKBOX  (13004, "  Button L"s,0);
+    MENU_MAKE_CHECKBOX  (13005, "  Button R"s,0);
+    MENU_MAKE_DISABLED  (""s);
+    MENU_MAKE_HEADER2   ("SRAM (Save Data)"s);
+    MENU_MAKE_PICKER    (17000, "  SRAM Auto-Save Delay"s,"Try setting to 60 seconds or Disabled this if the game saves SRAM (Save Data) to SD card too frequently."s,makeOptionsForAutoSaveSRAMDelay(), DIALOGCOLOR_CYAN);
+    MENU_MAKE_CHECKBOX  (19000, "  Force SRAM Write on Pause"s,0);
+    return items;
 };
 
-SMenuItem optionsForInFramePaletteChanges[] = {
-    MENU_MAKE_DIALOG_ACTION (1, "Enabled",          "Best (not 100% accurate); slower"),
-    MENU_MAKE_DIALOG_ACTION (2, "Disabled Style 1", "Faster than \"Enabled\""),
-    MENU_MAKE_DIALOG_ACTION (3, "Disabled Style 2", "Faster than \"Enabled\"")
+void menuSetupCheats(std::vector<SMenuItem>& cheatMenu);
+
+std::vector<SMenuItem> makeCheatMenu() {
+    std::vector<SMenuItem> items;
+    MENU_MAKE_HEADER2   ("Cheats"s);
+    menuSetupCheats(items);
+    return items;
 };
 
-SMenuItem emulatorNewMenu[] = {
-    MENU_MAKE_ACTION(6001, "  Exit")
-    };
+std::vector<SMenuItem> makeOptionsForNoYes() {
+    std::vector<SMenuItem> items;
+    MENU_MAKE_ACTION(0, "No"s);
+    MENU_MAKE_ACTION(1, "Yes"s);
+    return items;
+}
 
-SMenuItem optionMenu[] = {
-    MENU_MAKE_HEADER1   ("GLOBAL SETTINGS"),
-    MENU_MAKE_PICKER    (11000, "  Screen Stretch", "How would you like the final screen to appear?", optionsForStretch, DIALOGCOLOR_CYAN),
-    MENU_MAKE_PICKER    (18000, "  Font", "The font used for the user interface.", optionsForFont, DIALOGCOLOR_CYAN),
-    MENU_MAKE_CHECKBOX  (15001, "  Hide text in bottom screen", 0),
-    MENU_MAKE_DISABLED  (""),
-    MENU_MAKE_CHECKBOX  (19100, "  Automatically save state on exit and load state on start", 0),
-    MENU_MAKE_DISABLED  (""),
-    MENU_MAKE_HEADER1   ("GAME-SPECIFIC SETTINGS"),
-    MENU_MAKE_HEADER2   ("Graphics"),
-    MENU_MAKE_PICKER    (10000, "  Frameskip", "Try changing this if the game runs slow. Skipping frames help it run faster but less smooth.", optionsForFrameskip, DIALOGCOLOR_CYAN),
-    MENU_MAKE_PICKER    (12000, "  Framerate", "Some games run at 50 or 60 FPS by default. Override if required.", optionsForFrameRate, DIALOGCOLOR_CYAN),
-    MENU_MAKE_PICKER    (16000, "  In-Frame Palette Changes", "Try changing this if some colours in the game look off.", optionsForInFramePaletteChanges, DIALOGCOLOR_CYAN),
-    MENU_MAKE_DISABLED  (""),
-    MENU_MAKE_HEADER2   ("Audio"),
-    MENU_MAKE_GAUGE     (14000, "  Volume Amplification", 0, 8, 4),
-    MENU_MAKE_DISABLED  (""),
-    MENU_MAKE_HEADER2   ("Turbo (Auto-Fire) Buttons"),
-    MENU_MAKE_CHECKBOX  (13000, "  Button A", 0),
-    MENU_MAKE_CHECKBOX  (13001, "  Button B", 0),
-    MENU_MAKE_CHECKBOX  (13002, "  Button X", 0),
-    MENU_MAKE_CHECKBOX  (13003, "  Button Y", 0),
-    MENU_MAKE_CHECKBOX  (13004, "  Button L", 0),
-    MENU_MAKE_CHECKBOX  (13005, "  Button R", 0),
-    MENU_MAKE_DISABLED  (""),
-    MENU_MAKE_HEADER2   ("SRAM (Save Data)"),
-    MENU_MAKE_PICKER    (17000, "  SRAM Auto-Save Delay", "Try setting to 60 seconds or Disabled this if the game saves SRAM (Save Data) to SD card too frequently.", optionsForAutoSaveSRAMDelay, DIALOGCOLOR_CYAN),
-    MENU_MAKE_CHECKBOX  (19000, "  Force SRAM Write on Pause", 0)
-
-    };
-
-SMenuItem cheatMenu[MAX_CHEATS+1] =
-{
-    MENU_MAKE_HEADER2   ("Cheats")
-};
-
-char *amplificationText[9] =
-    {
-        "  Volume Amplification (1.00x)",
-        "  Volume Amplification (1.25x)",
-        "  Volume Amplification (1.50x)",
-        "  Volume Amplification (1.75x)",
-        "  Volume Amplification (2.00x)",
-        "  Volume Amplification (2.25x)",
-        "  Volume Amplification (2.50x)",
-        "  Volume Amplification (2.75x)",
-        "  Volume Amplification (3.00x)"
-    };
-int emulatorMenuCount = 0;
-int optionMenuCount = 0;
-int cheatMenuCount = 1;
-
-SMenuItem optionsForNoYes[] = {
-    MENU_MAKE_ACTION(0, "No"),
-    MENU_MAKE_ACTION(1, "Yes")
-};
-
-SMenuItem optionsForOk[] = {
-    MENU_MAKE_ACTION(0, "OK")
-};
+std::vector<SMenuItem> makeOptionsForOk() {
+    std::vector<SMenuItem> items;
+    MENU_MAKE_ACTION(0, "OK"s);
+    return items;
+}
 
 
 //----------------------------------------------------------------------
@@ -563,7 +558,6 @@ bool settingsLoad(bool includeGameSettings = true)
 //-------------------------------------------------------
 
 extern SCheatData Cheat;
-void menuSetupCheats();  // forward declaration
 
 void emulatorLoadRom()
 {
@@ -580,7 +574,6 @@ void emulatorLoadRom()
     consoleClear();
     settingsLoad();
     settingsUpdateAllSettings();
-    menuSetupCheats();
 
     if (settings3DS.AutoSavestate)
         impl3dsLoadStateAuto();
@@ -592,28 +585,21 @@ void emulatorLoadRom()
 //----------------------------------------------------------------------
 // Menus
 //----------------------------------------------------------------------
-SMenuItem fileMenu[1000];
 char romFileNames[1000][_MAX_PATH];
-
-int totalRomFileCount = 0;
 
 //----------------------------------------------------------------------
 // Load all ROM file names (up to 1000 ROMs)
 //----------------------------------------------------------------------
-void fileGetAllFiles(void)
+void fileGetAllFiles(std::vector<SMenuItem>& fileMenu)
 {
+    fileMenu.clear();
     std::vector<std::string> files = file3dsGetFiles("smc,sfc,fig", 1000);
-
-    totalRomFileCount = 0;
 
     // Increase the total number of files we can display.
     for (int i = 0; i < files.size() && i < 1000; i++)
     {
         strncpy(romFileNames[i], files[i].c_str(), _MAX_PATH);
-        totalRomFileCount++;
-        fileMenu[i].Type = MENUITEM_ACTION;
-        fileMenu[i].ID = i;
-        fileMenu[i].Text = romFileNames[i];
+        fileMenu.emplace_back(MENUITEM_ACTION, i, std::string(romFileNames[i]), ""s);
     }
 }
 
@@ -621,11 +607,11 @@ void fileGetAllFiles(void)
 //----------------------------------------------------------------------
 // Find the ID of the last selected file in the file list.
 //----------------------------------------------------------------------
-int fileFindLastSelectedFile()
+int fileFindLastSelectedFile(std::vector<SMenuItem>& fileMenu)
 {
-    for (int i = 0; i < totalRomFileCount && i < 1000; i++)
+    for (int i = 0; i < fileMenu.size() && i < 1000; i++)
     {
-        if (strncmp(fileMenu[i].Text, romFileNameLastSelected, _MAX_PATH) == 0)
+        if (strncmp(fileMenu[i].Text.c_str(), romFileNameLastSelected, _MAX_PATH) == 0)
             return i;
     }
     return -1;
@@ -675,10 +661,10 @@ bool menuCopySettings(std::vector<SMenuTab>& menuTab, bool copyMenuToSettings)
 //----------------------------------------------------------------------
 // Handle menu cheats.
 //----------------------------------------------------------------------
-bool menuCopyCheats(bool copyMenuToSettings)
+bool menuCopyCheats(std::vector<SMenuItem>& cheatMenu, bool copyMenuToSettings)
 {
     bool cheatsUpdated = false;
-    for (int i = 0; i < MAX_CHEATS && i < Cheat.num_cheats; i++)
+    for (int i = 0; (i+1) < cheatMenu.size() && i < MAX_CHEATS && i < Cheat.num_cheats; i++)
     {
         cheatMenu[i+1].Type = MENUITEM_CHECKBOX;
         cheatMenu[i+1].ID = 20000 + i;
@@ -713,18 +699,16 @@ void menuSelectFile(void)
     int currentMenuTab = 0;
     bool isDialog = false;
     SMenuTab dialogTab;
+    std::vector<SMenuItem> fileMenu;
 
     gfxSetDoubleBuffering(GFX_BOTTOM, true);
-    
-    emulatorMenuCount = sizeof(emulatorNewMenu) / sizeof(SMenuItem);
-    optionMenuCount = sizeof(optionMenu) / sizeof(SMenuItem);
 
-    fileGetAllFiles();
-    int previousFileID = fileFindLastSelectedFile();
+    fileGetAllFiles(fileMenu);
+    int previousFileID = fileFindLastSelectedFile(fileMenu);
     menuTab.clear();
     currentMenuTab = 0;
-    menu3dsAddTab(menuTab, "Emulator", emulatorNewMenu, emulatorMenuCount);
-    menu3dsAddTab(menuTab, "Select ROM", fileMenu, totalRomFileCount);
+    menu3dsAddTab(menuTab, "Emulator", makeEmulatorNewMenu());
+    menu3dsAddTab(menuTab, "Select ROM", fileMenu);
     menuTab[0].SubTitle.clear();
     menuTab[1].SubTitle.assign(file3dsGetCurrentDir());
     currentMenuTab = 1;
@@ -755,11 +739,11 @@ void menuSelectFile(void)
                 else
                     file3dsGoToChildDirectory(&romFileName[2]);
 
-                fileGetAllFiles();
+                fileGetAllFiles(fileMenu);
                 menuTab.clear();
                 currentMenuTab = 0;
-                menu3dsAddTab(menuTab, "Emulator", emulatorNewMenu, emulatorMenuCount);
-                menu3dsAddTab(menuTab, "Select ROM", fileMenu, totalRomFileCount);
+                menu3dsAddTab(menuTab, "Emulator", makeEmulatorNewMenu());
+                menu3dsAddTab(menuTab, "Select ROM", fileMenu);
                 currentMenuTab = 1;
                 menuTab[1].SubTitle.assign(file3dsGetCurrentDir());
                 selection = -1;
@@ -772,7 +756,7 @@ void menuSelectFile(void)
         }
         else if (selection == 6001)
         {
-            int result = menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Exit",  "Leaving so soon?", DIALOGCOLOR_RED, optionsForNoYes, sizeof(optionsForNoYes) / sizeof(SMenuItem));
+            int result = menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Exit",  "Leaving so soon?", DIALOGCOLOR_RED, makeOptionsForNoYes());
             menu3dsHideDialog(dialogTab, isDialog, currentMenuTab, menuTab);
 
             if (result == 1)
@@ -825,28 +809,29 @@ void menuPause()
     int currentMenuTab = 0;
     bool isDialog = false;
     SMenuTab dialogTab;
+    std::vector<SMenuItem> fileMenu;
 
     gfxSetDoubleBuffering(GFX_BOTTOM, true);
     
-    emulatorMenuCount = sizeof(emulatorMenu) / sizeof(SMenuItem);
-    optionMenuCount = sizeof(optionMenu) / sizeof(SMenuItem);
     bool settingsUpdated = false;
     bool cheatsUpdated = false;
     bool loadRomBeforeExit = false;
     bool returnToEmulation = false;
 
 
+    fileGetAllFiles(fileMenu);
     menuTab.clear();
     currentMenuTab = 0;
-    menu3dsAddTab(menuTab, "Emulator", emulatorMenu, emulatorMenuCount);
-    menu3dsAddTab(menuTab, "Options", optionMenu, optionMenuCount);
-    menu3dsAddTab(menuTab, "Cheats", cheatMenu, cheatMenuCount);
-    menu3dsAddTab(menuTab, "Select ROM", fileMenu, totalRomFileCount);
+    menu3dsAddTab(menuTab, "Emulator", makeEmulatorMenu());
+    menu3dsAddTab(menuTab, "Options", makeOptionMenu());
+    menu3dsAddTab(menuTab, "Cheats", makeCheatMenu());
+    menu3dsAddTab(menuTab, "Select ROM", fileMenu);
+    std::vector<SMenuItem>& cheatMenu = menuTab[2].MenuItems;
 
     menuCopySettings(menuTab, false);
-    menuCopyCheats(false);
+    menuCopyCheats(cheatMenu, false);
 
-    int previousFileID = fileFindLastSelectedFile();
+    int previousFileID = fileFindLastSelectedFile(fileMenu);
     menuTab[0].SubTitle.clear();
     menuTab[1].SubTitle.clear();
     menuTab[2].SubTitle.clear();
@@ -888,13 +873,13 @@ void menuPause()
                 else
                     file3dsGoToChildDirectory(&romFileName[2]);
 
-                fileGetAllFiles();
+                fileGetAllFiles(fileMenu);
                 menuTab.clear();
                 currentMenuTab = 0;
-                menu3dsAddTab(menuTab, "Emulator", emulatorMenu, emulatorMenuCount);
-                menu3dsAddTab(menuTab, "Options", optionMenu, optionMenuCount);
-                menu3dsAddTab(menuTab, "Cheats", cheatMenu, cheatMenuCount);
-                menu3dsAddTab(menuTab, "Select ROM", fileMenu, totalRomFileCount);
+                menu3dsAddTab(menuTab, "Emulator", makeEmulatorMenu());
+                menu3dsAddTab(menuTab, "Options", makeOptionMenu());
+                menu3dsAddTab(menuTab, "Cheats", makeCheatMenu());
+                menu3dsAddTab(menuTab, "Select ROM", fileMenu);
                 currentMenuTab = 3;
                 menuTab[3].SubTitle.assign(file3dsGetCurrentDir());
             }
@@ -908,13 +893,13 @@ void menuPause()
 
                 if (settings3DS.AutoSavestate)
                 {
-                    menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Save State", "Autosaving...", DIALOGCOLOR_CYAN, NULL, 0);
+                    menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Save State", "Autosaving...", DIALOGCOLOR_CYAN, std::vector<SMenuItem>());
                     bool result = impl3dsSaveStateAuto();
                     menu3dsHideDialog(dialogTab, isDialog, currentMenuTab, menuTab);
 
                     if (!result)
                     {
-                        int choice = menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Autosave failure", "Automatic savestate writing failed.\nLoad chosen game anyway?", DIALOGCOLOR_RED, optionsForNoYes, sizeof(optionsForNoYes) / sizeof(SMenuItem));
+                        int choice = menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Autosave failure", "Automatic savestate writing failed.\nLoad chosen game anyway?", DIALOGCOLOR_RED, makeOptionsForNoYes());
                         if (choice != 1)
                             loadRom = false;
                     }
@@ -934,20 +919,20 @@ void menuPause()
             char text[200];
            
             sprintf(text, "Saving into slot %d...\nThis may take a while", slot);
-            menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Savestates", text, DIALOGCOLOR_CYAN, NULL, 0);
+            menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Savestates", text, DIALOGCOLOR_CYAN, std::vector<SMenuItem>());
             bool result = impl3dsSaveStateSlot(slot);
             menu3dsHideDialog(dialogTab, isDialog, currentMenuTab, menuTab);
 
             if (result)
             {
                 sprintf(text, "Slot %d save completed.", slot);
-                result = menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Savestates", text, DIALOGCOLOR_GREEN, optionsForOk, sizeof(optionsForOk) / sizeof(SMenuItem));
+                result = menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Savestates", text, DIALOGCOLOR_GREEN, makeOptionsForOk());
                 menu3dsHideDialog(dialogTab, isDialog, currentMenuTab, menuTab);
             }
             else
             {
                 sprintf(text, "Oops. Unable to save slot %d!", slot);
-                result = menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Savestates", text, DIALOGCOLOR_RED, optionsForOk, sizeof(optionsForOk) / sizeof(SMenuItem));
+                result = menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Savestates", text, DIALOGCOLOR_RED, makeOptionsForOk());
                 menu3dsHideDialog(dialogTab, isDialog, currentMenuTab, menuTab);
             }
 
@@ -968,13 +953,13 @@ void menuPause()
             else
             {
                 sprintf(text, "Oops. Unable to load slot %d!", slot);
-                menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Savestates", text, DIALOGCOLOR_RED, optionsForOk, sizeof(optionsForOk) / sizeof(SMenuItem));
+                menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Savestates", text, DIALOGCOLOR_RED, makeOptionsForOk());
                 menu3dsHideDialog(dialogTab, isDialog, currentMenuTab, menuTab);
             }
         }
         else if (selection == 4001)
         {
-            menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Screenshot", "Now taking a screenshot...\nThis may take a while.", DIALOGCOLOR_CYAN, NULL, 0);
+            menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Screenshot", "Now taking a screenshot...\nThis may take a while.", DIALOGCOLOR_CYAN, std::vector<SMenuItem>());
 
             char ext[256];
             const char *path = NULL;
@@ -1004,18 +989,18 @@ void menuPause()
             {
                 char text[600];
                 snprintf(text, 600, "Done! File saved to %s", path);
-                menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Screenshot", text, DIALOGCOLOR_GREEN, optionsForOk, sizeof(optionsForOk)/sizeof(SMenuItem));
+                menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Screenshot", text, DIALOGCOLOR_GREEN, makeOptionsForOk());
                 menu3dsHideDialog(dialogTab, isDialog, currentMenuTab, menuTab);
             }
             else 
             {
-                menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Screenshot", "Oops. Unable to take screenshot!", DIALOGCOLOR_RED, optionsForOk, sizeof(optionsForOk)/sizeof(SMenuItem));
+                menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Screenshot", "Oops. Unable to take screenshot!", DIALOGCOLOR_RED, makeOptionsForOk());
                 menu3dsHideDialog(dialogTab, isDialog, currentMenuTab, menuTab);
             }
         }
         else if (selection == 5001)
         {
-            int result = menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Reset Console", "Are you sure?", DIALOGCOLOR_RED, optionsForNoYes, sizeof(optionsForNoYes) / sizeof(SMenuItem));
+            int result = menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Reset Console", "Are you sure?", DIALOGCOLOR_RED, makeOptionsForNoYes());
             menu3dsHideDialog(dialogTab, isDialog, currentMenuTab, menuTab);
 
             if (result == 1)
@@ -1030,7 +1015,7 @@ void menuPause()
         }
         else if (selection == 6001)
         {
-            int result = menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Exit",  "Leaving so soon?", DIALOGCOLOR_RED, optionsForNoYes, sizeof(optionsForNoYes) / sizeof(SMenuItem));
+            int result = menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Exit",  "Leaving so soon?", DIALOGCOLOR_RED, makeOptionsForNoYes());
             if (result == 1)
             {
                 GPU3DS.emulatorState = EMUSTATE_END;
@@ -1052,7 +1037,7 @@ void menuPause()
         settingsSave();
     settingsUpdateAllSettings();
 
-    if (menuCopyCheats(true))
+    if (menuCopyCheats(cheatMenu, true))
     {
         // Only one of these will succeeed.
         S9xSaveCheatFile (S9xGetFilename(".cht"));
@@ -1092,33 +1077,20 @@ char *noCheatsText[] {
     ""
      };
 
-void menuSetupCheats()
+void menuSetupCheats(std::vector<SMenuItem>& cheatMenu)
 {
     if (Cheat.num_cheats > 0)
     {
-        cheatMenuCount = Cheat.num_cheats + 1;
-
-        // Bug fix: If the number of cheats exceeds what we can store,
-        // make sure we limit it.
-        //
-        if (cheatMenuCount > MAX_CHEATS)
-            cheatMenuCount = MAX_CHEATS;
         for (int i = 0; i < MAX_CHEATS && i < Cheat.num_cheats; i++)
         {
-            cheatMenu[i+1].Type = MENUITEM_CHECKBOX;
-            cheatMenu[i+1].ID = 20000 + i;
-            cheatMenu[i+1].Text = Cheat.c[i].name;
-            cheatMenu[i+1].Value = Cheat.c[i].enabled ? 1 : 0;
+            cheatMenu.emplace_back( MENUITEM_CHECKBOX, 20000+i, std::string(Cheat.c[i].name), ""s, Cheat.c[i].enabled ? 1 : 0 );
         }
     }
     else
     {
-        cheatMenuCount = 14;
-        for (int i = 0; i < cheatMenuCount; i++)
+        for (int i = 0; i < 14; i++)
         {
-            cheatMenu[i+1].Type = MENUITEM_DISABLED;
-            cheatMenu[i+1].ID = -2;
-            cheatMenu[i+1].Text = noCheatsText[i];
+            cheatMenu.emplace_back(MENUITEM_DISABLED, -2, std::string(noCheatsText[i]), ""s);
         }
     }
 }

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -102,54 +102,54 @@ void clearTopScreenWithLogo()
 // Menu options
 //----------------------------------------------------------------------
 
-#define MENU_MAKE_ACTION(ID, text) \
-    items.emplace_back( MENUITEM_ACTION, ID, text, ""s, 0 )
+#define MENU_MAKE_ACTION(ID, text, callback) \
+    items.emplace_back( callback, MENUITEM_ACTION, ID, text, ""s, 0 )
 
 #define MENU_MAKE_DIALOG_ACTION(ID, text, desc) \
-    items.emplace_back( MENUITEM_ACTION, ID, text, desc, 0 )
+    items.emplace_back( nullptr, MENUITEM_ACTION, ID, text, desc, 0 )
 
 #define MENU_MAKE_DISABLED(text) \
-    items.emplace_back( MENUITEM_DISABLED, -1, text, ""s )
+    items.emplace_back( nullptr, MENUITEM_DISABLED, -1, text, ""s )
 
 #define MENU_MAKE_HEADER1(text) \
-    items.emplace_back( MENUITEM_HEADER1, -1, text, ""s )
+    items.emplace_back( nullptr, MENUITEM_HEADER1, -1, text, ""s )
 
 #define MENU_MAKE_HEADER2(text) \
-    items.emplace_back( MENUITEM_HEADER2, -1, text, ""s )
+    items.emplace_back( nullptr, MENUITEM_HEADER2, -1, text, ""s )
 
-#define MENU_MAKE_CHECKBOX(ID, text, value) \
-    items.emplace_back( MENUITEM_CHECKBOX, ID, text, ""s, value )
+#define MENU_MAKE_CHECKBOX(ID, text, value, callback) \
+    items.emplace_back( callback, MENUITEM_CHECKBOX, ID, text, ""s, value )
 
-#define MENU_MAKE_GAUGE(ID, text, min, max, value) \
-    items.emplace_back( MENUITEM_GAUGE, ID, text, ""s, value, min, max )
+#define MENU_MAKE_GAUGE(ID, text, min, max, value, callback) \
+    items.emplace_back( callback, MENUITEM_GAUGE, ID, text, ""s, value, min, max )
 
-#define MENU_MAKE_PICKER(ID, text, pickerDescription, pickerOptions, backColor) \
-    items.emplace_back( MENUITEM_PICKER, ID, text, ""s, 0, 0, 0, pickerDescription, pickerOptions, backColor )
+#define MENU_MAKE_PICKER(ID, text, pickerDescription, pickerOptions, value, backColor, callback) \
+    items.emplace_back( callback, MENUITEM_PICKER, ID, text, ""s, value, 0, 0, pickerDescription, pickerOptions, backColor )
 
 
 std::vector<SMenuItem> makeEmulatorMenu() {
     std::vector<SMenuItem> items;
     MENU_MAKE_HEADER2   ("Resume"s);
-    MENU_MAKE_ACTION    (1000, "  Resume Game"s);
+    MENU_MAKE_ACTION    (1000, "  Resume Game"s, nullptr); // TODO!
     MENU_MAKE_HEADER2   (""s);
 
     MENU_MAKE_HEADER2   ("Savestates"s);
-    MENU_MAKE_ACTION    (2001, "  Save Slot #1"s);
-    MENU_MAKE_ACTION    (2002, "  Save Slot #2"s);
-    MENU_MAKE_ACTION    (2003, "  Save Slot #3"s);
-    MENU_MAKE_ACTION    (2004, "  Save Slot #4"s);
+    MENU_MAKE_ACTION    (2001, "  Save Slot #1"s, nullptr); // TODO!
+    MENU_MAKE_ACTION    (2002, "  Save Slot #2"s, nullptr); // TODO!
+    MENU_MAKE_ACTION    (2003, "  Save Slot #3"s, nullptr); // TODO!
+    MENU_MAKE_ACTION    (2004, "  Save Slot #4"s, nullptr); // TODO!
     MENU_MAKE_HEADER2   (""s);
     
-    MENU_MAKE_ACTION    (3001, "  Load Slot #1"s);
-    MENU_MAKE_ACTION    (3002, "  Load Slot #2"s);
-    MENU_MAKE_ACTION    (3003, "  Load Slot #3"s);
-    MENU_MAKE_ACTION    (3004, "  Load Slot #4"s);
+    MENU_MAKE_ACTION    (3001, "  Load Slot #1"s, nullptr); // TODO!
+    MENU_MAKE_ACTION    (3002, "  Load Slot #2"s, nullptr); // TODO!
+    MENU_MAKE_ACTION    (3003, "  Load Slot #3"s, nullptr); // TODO!
+    MENU_MAKE_ACTION    (3004, "  Load Slot #4"s, nullptr); // TODO!
     MENU_MAKE_HEADER2   (""s);
 
     MENU_MAKE_HEADER2   ("Others"s);
-    MENU_MAKE_ACTION    (4001, "  Take Screenshot"s);
-    MENU_MAKE_ACTION    (5001, "  Reset Console"s);
-    MENU_MAKE_ACTION    (6001, "  Exit"s);
+    MENU_MAKE_ACTION    (4001, "  Take Screenshot"s, nullptr); // TODO!
+    MENU_MAKE_ACTION    (5001, "  Reset Console"s, nullptr); // TODO!
+    MENU_MAKE_ACTION    (6001, "  Exit"s, nullptr); // TODO!
     return items;
 }
 
@@ -211,39 +211,49 @@ std::vector<SMenuItem> makeOptionsForInFramePaletteChanges() {
 
 std::vector<SMenuItem> makeEmulatorNewMenu() {
     std::vector<SMenuItem> items;
-    MENU_MAKE_ACTION(6001, "  Exit"s);
+    MENU_MAKE_ACTION(6001, "  Exit"s, nullptr); // TODO!
     return items;
 }
 
 std::vector<SMenuItem> makeOptionMenu() {
     std::vector<SMenuItem> items;
     MENU_MAKE_HEADER1   ("GLOBAL SETTINGS"s);
-    MENU_MAKE_PICKER    (11000, "  Screen Stretch"s,"How would you like the final screen to appear?"s,makeOptionsForStretch(), DIALOGCOLOR_CYAN);
-    MENU_MAKE_PICKER    (18000, "  Font"s,"The font used for the user interface."s,makeOptionsForFont(), DIALOGCOLOR_CYAN);
-    MENU_MAKE_CHECKBOX  (15001, "  Hide text in bottom screen"s,0);
+    MENU_MAKE_PICKER    (11000, "  Screen Stretch"s, "How would you like the final screen to appear?"s, makeOptionsForStretch(), settings3DS.ScreenStretch, DIALOGCOLOR_CYAN,
+                         []( int val ) { settings3DS.ScreenStretch = val; });
+    MENU_MAKE_PICKER    (18000, "  Font"s, "The font used for the user interface."s, makeOptionsForFont(), settings3DS.Font, DIALOGCOLOR_CYAN,
+                         []( int val ) { settings3DS.Font = val; ui3dsSetFont(val); });
+    MENU_MAKE_CHECKBOX  (15001, "  Hide text in bottom screen"s, 0,
+                         []( int val ) { settings3DS.HideUnnecessaryBottomScrText = val; });
     MENU_MAKE_DISABLED  (""s);
-    MENU_MAKE_CHECKBOX  (19100, "  Automatically save state on exit and load state on start"s,0);
+    MENU_MAKE_CHECKBOX  (19100, "  Automatically save state on exit and load state on start"s, settings3DS.AutoSavestate,
+                         []( int val ) { settings3DS.AutoSavestate = val; });
     MENU_MAKE_DISABLED  (""s);
     MENU_MAKE_HEADER1   ("GAME-SPECIFIC SETTINGS"s);
     MENU_MAKE_HEADER2   ("Graphics"s);
-    MENU_MAKE_PICKER    (10000, "  Frameskip"s,"Try changing this if the game runs slow. Skipping frames help it run faster but less smooth."s,makeOptionsForFrameskip(), DIALOGCOLOR_CYAN);
-    MENU_MAKE_PICKER    (12000, "  Framerate"s,"Some games run at 50 or 60 FPS by default. Override if required."s,makeOptionsForFrameRate(), DIALOGCOLOR_CYAN);
-    MENU_MAKE_PICKER    (16000, "  In-Frame Palette Changes"s,"Try changing this if some colours in the game look off."s,makeOptionsForInFramePaletteChanges(), DIALOGCOLOR_CYAN);
+    MENU_MAKE_PICKER    (10000, "  Frameskip"s, "Try changing this if the game runs slow. Skipping frames help it run faster but less smooth."s, makeOptionsForFrameskip(), settings3DS.MaxFrameSkips, DIALOGCOLOR_CYAN,
+                         []( int val ) { settings3DS.MaxFrameSkips = val; });
+    MENU_MAKE_PICKER    (12000, "  Framerate"s, "Some games run at 50 or 60 FPS by default. Override if required."s, makeOptionsForFrameRate(), settings3DS.ForceFrameRate, DIALOGCOLOR_CYAN,
+                         []( int val ) { settings3DS.ForceFrameRate = val; });
+    MENU_MAKE_PICKER    (16000, "  In-Frame Palette Changes"s, "Try changing this if some colours in the game look off."s, makeOptionsForInFramePaletteChanges(), settings3DS.PaletteFix, DIALOGCOLOR_CYAN,
+                         []( int val ) { settings3DS.PaletteFix = val; });
     MENU_MAKE_DISABLED  (""s);
     MENU_MAKE_HEADER2   ("Audio"s);
-    MENU_MAKE_GAUGE     (14000, "  Volume Amplification"s,0, 8, 4);
+    MENU_MAKE_GAUGE     (14000, "  Volume Amplification"s, 0, 8, settings3DS.Volume,
+                         []( int val ) { settings3DS.Volume = val; });
     MENU_MAKE_DISABLED  (""s);
     MENU_MAKE_HEADER2   ("Turbo (Auto-Fire) Buttons"s);
-    MENU_MAKE_CHECKBOX  (13000, "  Button A"s,0);
-    MENU_MAKE_CHECKBOX  (13001, "  Button B"s,0);
-    MENU_MAKE_CHECKBOX  (13002, "  Button X"s,0);
-    MENU_MAKE_CHECKBOX  (13003, "  Button Y"s,0);
-    MENU_MAKE_CHECKBOX  (13004, "  Button L"s,0);
-    MENU_MAKE_CHECKBOX  (13005, "  Button R"s,0);
+    MENU_MAKE_CHECKBOX  (13000, "  Button A"s, settings3DS.Turbo[0], []( int val ) { settings3DS.Turbo[0] = val; });
+    MENU_MAKE_CHECKBOX  (13001, "  Button B"s, settings3DS.Turbo[1], []( int val ) { settings3DS.Turbo[1] = val; });
+    MENU_MAKE_CHECKBOX  (13002, "  Button X"s, settings3DS.Turbo[2], []( int val ) { settings3DS.Turbo[2] = val; });
+    MENU_MAKE_CHECKBOX  (13003, "  Button Y"s, settings3DS.Turbo[3], []( int val ) { settings3DS.Turbo[3] = val; });
+    MENU_MAKE_CHECKBOX  (13004, "  Button L"s, settings3DS.Turbo[4], []( int val ) { settings3DS.Turbo[4] = val; });
+    MENU_MAKE_CHECKBOX  (13005, "  Button R"s, settings3DS.Turbo[5], []( int val ) { settings3DS.Turbo[5] = val; });
     MENU_MAKE_DISABLED  (""s);
     MENU_MAKE_HEADER2   ("SRAM (Save Data)"s);
-    MENU_MAKE_PICKER    (17000, "  SRAM Auto-Save Delay"s,"Try setting to 60 seconds or Disabled this if the game saves SRAM (Save Data) to SD card too frequently."s,makeOptionsForAutoSaveSRAMDelay(), DIALOGCOLOR_CYAN);
-    MENU_MAKE_CHECKBOX  (19000, "  Force SRAM Write on Pause"s,0);
+    MENU_MAKE_PICKER    (17000, "  SRAM Auto-Save Delay"s, "Try setting to 60 seconds or Disabled this if the game saves SRAM (Save Data) to SD card too frequently."s, makeOptionsForAutoSaveSRAMDelay(), settings3DS.SRAMSaveInterval, DIALOGCOLOR_CYAN,
+                         []( int val ) { settings3DS.SRAMSaveInterval = val; });
+    MENU_MAKE_CHECKBOX  (19000, "  Force SRAM Write on Pause"s, settings3DS.ForceSRAMWriteOnPause,
+                         []( int val ) { settings3DS.ForceSRAMWriteOnPause = val; });
     return items;
 };
 
@@ -258,14 +268,14 @@ std::vector<SMenuItem> makeCheatMenu() {
 
 std::vector<SMenuItem> makeOptionsForNoYes() {
     std::vector<SMenuItem> items;
-    MENU_MAKE_ACTION(0, "No"s);
-    MENU_MAKE_ACTION(1, "Yes"s);
+    MENU_MAKE_ACTION(0, "No"s, nullptr);
+    MENU_MAKE_ACTION(1, "Yes"s, nullptr);
     return items;
 }
 
 std::vector<SMenuItem> makeOptionsForOk() {
     std::vector<SMenuItem> items;
-    MENU_MAKE_ACTION(0, "OK"s);
+    MENU_MAKE_ACTION(0, "OK"s, nullptr);
     return items;
 }
 
@@ -599,7 +609,7 @@ void fileGetAllFiles(std::vector<SMenuItem>& fileMenu)
     for (int i = 0; i < files.size() && i < 1000; i++)
     {
         strncpy(romFileNames[i], files[i].c_str(), _MAX_PATH);
-        fileMenu.emplace_back(MENUITEM_ACTION, i, std::string(romFileNames[i]), ""s);
+        fileMenu.emplace_back(nullptr, MENUITEM_ACTION, i, std::string(romFileNames[i]), ""s);
     }
 }
 
@@ -637,22 +647,22 @@ bool menuCopySettings(std::vector<SMenuTab>& menuTab, bool copyMenuToSettings)
     }
 
     bool settingsUpdated = false;
-    UPDATE_SETTINGS(settings3DS.Font, 1, 18000);
-    UPDATE_SETTINGS(settings3DS.ScreenStretch, 1, 11000);
-    UPDATE_SETTINGS(settings3DS.HideUnnecessaryBottomScrText, 1, 15001);
-    UPDATE_SETTINGS(settings3DS.MaxFrameSkips, 1, 10000);
-    UPDATE_SETTINGS(settings3DS.ForceFrameRate, 1, 12000);
-    UPDATE_SETTINGS(settings3DS.Turbo[0], 1, 13000);
-    UPDATE_SETTINGS(settings3DS.Turbo[1], 1, 13001);
-    UPDATE_SETTINGS(settings3DS.Turbo[2], 1, 13002);
-    UPDATE_SETTINGS(settings3DS.Turbo[3], 1, 13003);
-    UPDATE_SETTINGS(settings3DS.Turbo[4], 1, 13004);
-    UPDATE_SETTINGS(settings3DS.Turbo[5], 1, 13005);
-    UPDATE_SETTINGS(settings3DS.Volume, 1, 14000);
-    UPDATE_SETTINGS(settings3DS.PaletteFix, 1, 16000);
-    UPDATE_SETTINGS(settings3DS.AutoSavestate, 1, 19100);
-    UPDATE_SETTINGS(settings3DS.SRAMSaveInterval, 1, 17000);
-    UPDATE_SETTINGS(settings3DS.ForceSRAMWriteOnPause, 1, 19000);
+    //UPDATE_SETTINGS(settings3DS.Font, 1, 18000);
+    //UPDATE_SETTINGS(settings3DS.ScreenStretch, 1, 11000);
+    //UPDATE_SETTINGS(settings3DS.HideUnnecessaryBottomScrText, 1, 15001);
+    //UPDATE_SETTINGS(settings3DS.MaxFrameSkips, 1, 10000);
+    //UPDATE_SETTINGS(settings3DS.ForceFrameRate, 1, 12000);
+    //UPDATE_SETTINGS(settings3DS.Turbo[0], 1, 13000);
+    //UPDATE_SETTINGS(settings3DS.Turbo[1], 1, 13001);
+    //UPDATE_SETTINGS(settings3DS.Turbo[2], 1, 13002);
+    //UPDATE_SETTINGS(settings3DS.Turbo[3], 1, 13003);
+    //UPDATE_SETTINGS(settings3DS.Turbo[4], 1, 13004);
+    //UPDATE_SETTINGS(settings3DS.Turbo[5], 1, 13005);
+    //UPDATE_SETTINGS(settings3DS.Volume, 1, 14000);
+    //UPDATE_SETTINGS(settings3DS.PaletteFix, 1, 16000);
+    //UPDATE_SETTINGS(settings3DS.AutoSavestate, 1, 19100);
+    //UPDATE_SETTINGS(settings3DS.SRAMSaveInterval, 1, 17000);
+    //UPDATE_SETTINGS(settings3DS.ForceSRAMWriteOnPause, 1, 19000);
 
     return settingsUpdated;
 }
@@ -683,7 +693,7 @@ bool menuCopyCheats(std::vector<SMenuItem>& cheatMenu, bool copyMenuToSettings)
             }
         }
         else
-            cheatMenu[i+1].Value = Cheat.c[i].enabled;
+            cheatMenu[i+1].SetValue(Cheat.c[i].enabled);
     }
     
     return cheatsUpdated;
@@ -723,7 +733,7 @@ void menuSelectFile(void)
         if (appExiting)
             return;
 
-        selection = menu3dsShowMenu(dialogTab, isDialog, currentMenuTab, menuTab, NULL, animateMenu);
+        selection = menu3dsShowMenu(dialogTab, isDialog, currentMenuTab, menuTab, animateMenu);
         animateMenu = false;
 
         if (selection >= 0 && selection < 1000)
@@ -793,10 +803,6 @@ bool IsFileExists(const char * filename) {
 //----------------------------------------------------------------------
 void menuItemChangedCallback(int ID, int value)
 {
-    if (ID == 18000)
-    {
-        ui3dsSetFont(value);
-    }
 }
 
 
@@ -850,7 +856,7 @@ void menuPause()
             break;
         }
 
-        int selection = menu3dsShowMenu(dialogTab, isDialog, currentMenuTab, menuTab, menuItemChangedCallback, animateMenu);
+        int selection = menu3dsShowMenu(dialogTab, isDialog, currentMenuTab, menuTab, animateMenu);
         animateMenu = false;
 
         if (selection == -1 || selection == 1000)
@@ -1083,14 +1089,14 @@ void menuSetupCheats(std::vector<SMenuItem>& cheatMenu)
     {
         for (int i = 0; i < MAX_CHEATS && i < Cheat.num_cheats; i++)
         {
-            cheatMenu.emplace_back( MENUITEM_CHECKBOX, 20000+i, std::string(Cheat.c[i].name), ""s, Cheat.c[i].enabled ? 1 : 0 );
+            cheatMenu.emplace_back(nullptr, MENUITEM_CHECKBOX, 20000+i, std::string(Cheat.c[i].name), ""s, Cheat.c[i].enabled ? 1 : 0);
         }
     }
     else
     {
         for (int i = 0; i < 14; i++)
         {
-            cheatMenu.emplace_back(MENUITEM_DISABLED, -2, std::string(noCheatsText[i]), ""s);
+            cheatMenu.emplace_back(nullptr, MENUITEM_DISABLED, -2, std::string(noCheatsText[i]), ""s);
         }
     }
 }

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -724,8 +724,8 @@ void menuSelectFile(void)
     currentMenuTab = 0;
     menu3dsAddTab(menuTab, "Emulator", emulatorNewMenu, emulatorMenuCount);
     menu3dsAddTab(menuTab, "Select ROM", fileMenu, totalRomFileCount);
-    menu3dsSetTabSubTitle(menuTab, 0, NULL);
-    menu3dsSetTabSubTitle(menuTab, 1, file3dsGetCurrentDir());
+    menuTab[0].SubTitle.clear();
+    menuTab[1].SubTitle.assign(file3dsGetCurrentDir());
     currentMenuTab = 1;
     if (previousFileID >= 0)
         menu3dsSetSelectedItemIndexByID(currentMenuTab, menuTab, 1, previousFileID);
@@ -760,7 +760,7 @@ void menuSelectFile(void)
                 menu3dsAddTab(menuTab, "Emulator", emulatorNewMenu, emulatorMenuCount);
                 menu3dsAddTab(menuTab, "Select ROM", fileMenu, totalRomFileCount);
                 currentMenuTab = 1;
-                menu3dsSetTabSubTitle(menuTab, 1, file3dsGetCurrentDir());
+                menuTab[1].SubTitle.assign(file3dsGetCurrentDir());
                 selection = -1;
             }
             else
@@ -845,10 +845,10 @@ void menuPause()
     menuCopyCheats(false);
 
     int previousFileID = fileFindLastSelectedFile();
-    menu3dsSetTabSubTitle(menuTab, 0, NULL);
-    menu3dsSetTabSubTitle(menuTab, 1, NULL);
-    menu3dsSetTabSubTitle(menuTab, 2, NULL);
-    menu3dsSetTabSubTitle(menuTab, 3, file3dsGetCurrentDir());
+    menuTab[0].SubTitle.clear();
+    menuTab[1].SubTitle.clear();
+    menuTab[2].SubTitle.clear();
+    menuTab[3].SubTitle.assign(file3dsGetCurrentDir());
     if (previousFileID >= 0)
         menu3dsSetSelectedItemIndexByID(currentMenuTab, menuTab, 3, previousFileID);
     currentMenuTab = 0;
@@ -894,7 +894,7 @@ void menuPause()
                 menu3dsAddTab(menuTab, "Cheats", cheatMenu, cheatMenuCount);
                 menu3dsAddTab(menuTab, "Select ROM", fileMenu, totalRomFileCount);
                 currentMenuTab = 3;
-                menu3dsSetTabSubTitle(menuTab, 3, file3dsGetCurrentDir());
+                menuTab[3].SubTitle.assign(file3dsGetCurrentDir());
             }
             else
             {

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -101,6 +101,18 @@ void clearTopScreenWithLogo()
 // Menu options
 //----------------------------------------------------------------------
 
+namespace {
+    template <typename T>
+    bool CheckAndUpdate( T& oldValue, const T& newValue, bool& changed ) {
+        if ( oldValue != newValue ) {
+            oldValue = newValue;
+            changed = true;
+            return true;
+        }
+        return false;
+    }
+}
+
 #define MENU_MAKE_ACTION(ID, text, callback) \
     items.emplace_back( callback, MENUITEM_ACTION, ID, text, ""s, 0 )
 
@@ -218,41 +230,41 @@ std::vector<SMenuItem> makeOptionMenu() {
     std::vector<SMenuItem> items;
     MENU_MAKE_HEADER1   ("GLOBAL SETTINGS"s);
     MENU_MAKE_PICKER    (11000, "  Screen Stretch"s, "How would you like the final screen to appear?"s, makeOptionsForStretch(), settings3DS.ScreenStretch, DIALOGCOLOR_CYAN,
-                         []( int val ) { settings3DS.ScreenStretch = val; });
+                         []( int val ) { CheckAndUpdate( settings3DS.ScreenStretch, val, settings3DS.Changed ); });
     MENU_MAKE_PICKER    (18000, "  Font"s, "The font used for the user interface."s, makeOptionsForFont(), settings3DS.Font, DIALOGCOLOR_CYAN,
-                         []( int val ) { settings3DS.Font = val; ui3dsSetFont(val); });
-    MENU_MAKE_CHECKBOX  (15001, "  Hide text in bottom screen"s, 0,
-                         []( int val ) { settings3DS.HideUnnecessaryBottomScrText = val; });
+                         []( int val ) { if ( CheckAndUpdate( settings3DS.Font, val, settings3DS.Changed ) ) { ui3dsSetFont(val); } });
+    MENU_MAKE_CHECKBOX  (15001, "  Hide text in bottom screen"s, settings3DS.HideUnnecessaryBottomScrText,
+                         []( int val ) { CheckAndUpdate( settings3DS.HideUnnecessaryBottomScrText, val, settings3DS.Changed ); });
     MENU_MAKE_DISABLED  (""s);
     MENU_MAKE_CHECKBOX  (19100, "  Automatically save state on exit and load state on start"s, settings3DS.AutoSavestate,
-                         []( int val ) { settings3DS.AutoSavestate = val; });
+                         []( int val ) { CheckAndUpdate( settings3DS.AutoSavestate, val, settings3DS.Changed ); });
     MENU_MAKE_DISABLED  (""s);
     MENU_MAKE_HEADER1   ("GAME-SPECIFIC SETTINGS"s);
     MENU_MAKE_HEADER2   ("Graphics"s);
     MENU_MAKE_PICKER    (10000, "  Frameskip"s, "Try changing this if the game runs slow. Skipping frames help it run faster but less smooth."s, makeOptionsForFrameskip(), settings3DS.MaxFrameSkips, DIALOGCOLOR_CYAN,
-                         []( int val ) { settings3DS.MaxFrameSkips = val; });
+                         []( int val ) { CheckAndUpdate( settings3DS.MaxFrameSkips, val, settings3DS.Changed ); });
     MENU_MAKE_PICKER    (12000, "  Framerate"s, "Some games run at 50 or 60 FPS by default. Override if required."s, makeOptionsForFrameRate(), settings3DS.ForceFrameRate, DIALOGCOLOR_CYAN,
-                         []( int val ) { settings3DS.ForceFrameRate = val; });
+                         []( int val ) { CheckAndUpdate( settings3DS.ForceFrameRate, val, settings3DS.Changed ); });
     MENU_MAKE_PICKER    (16000, "  In-Frame Palette Changes"s, "Try changing this if some colours in the game look off."s, makeOptionsForInFramePaletteChanges(), settings3DS.PaletteFix, DIALOGCOLOR_CYAN,
-                         []( int val ) { settings3DS.PaletteFix = val; });
+                         []( int val ) { CheckAndUpdate( settings3DS.PaletteFix, val, settings3DS.Changed ); });
     MENU_MAKE_DISABLED  (""s);
     MENU_MAKE_HEADER2   ("Audio"s);
     MENU_MAKE_GAUGE     (14000, "  Volume Amplification"s, 0, 8, settings3DS.Volume,
-                         []( int val ) { settings3DS.Volume = val; });
+                         []( int val ) { CheckAndUpdate( settings3DS.Volume, val, settings3DS.Changed ); });
     MENU_MAKE_DISABLED  (""s);
     MENU_MAKE_HEADER2   ("Turbo (Auto-Fire) Buttons"s);
-    MENU_MAKE_CHECKBOX  (13000, "  Button A"s, settings3DS.Turbo[0], []( int val ) { settings3DS.Turbo[0] = val; });
-    MENU_MAKE_CHECKBOX  (13001, "  Button B"s, settings3DS.Turbo[1], []( int val ) { settings3DS.Turbo[1] = val; });
-    MENU_MAKE_CHECKBOX  (13002, "  Button X"s, settings3DS.Turbo[2], []( int val ) { settings3DS.Turbo[2] = val; });
-    MENU_MAKE_CHECKBOX  (13003, "  Button Y"s, settings3DS.Turbo[3], []( int val ) { settings3DS.Turbo[3] = val; });
-    MENU_MAKE_CHECKBOX  (13004, "  Button L"s, settings3DS.Turbo[4], []( int val ) { settings3DS.Turbo[4] = val; });
-    MENU_MAKE_CHECKBOX  (13005, "  Button R"s, settings3DS.Turbo[5], []( int val ) { settings3DS.Turbo[5] = val; });
+    MENU_MAKE_CHECKBOX  (13000, "  Button A"s, settings3DS.Turbo[0], []( int val ) { CheckAndUpdate( settings3DS.Turbo[0], val, settings3DS.Changed ); });
+    MENU_MAKE_CHECKBOX  (13001, "  Button B"s, settings3DS.Turbo[1], []( int val ) { CheckAndUpdate( settings3DS.Turbo[1], val, settings3DS.Changed ); });
+    MENU_MAKE_CHECKBOX  (13002, "  Button X"s, settings3DS.Turbo[2], []( int val ) { CheckAndUpdate( settings3DS.Turbo[2], val, settings3DS.Changed ); });
+    MENU_MAKE_CHECKBOX  (13003, "  Button Y"s, settings3DS.Turbo[3], []( int val ) { CheckAndUpdate( settings3DS.Turbo[3], val, settings3DS.Changed ); });
+    MENU_MAKE_CHECKBOX  (13004, "  Button L"s, settings3DS.Turbo[4], []( int val ) { CheckAndUpdate( settings3DS.Turbo[4], val, settings3DS.Changed ); });
+    MENU_MAKE_CHECKBOX  (13005, "  Button R"s, settings3DS.Turbo[5], []( int val ) { CheckAndUpdate( settings3DS.Turbo[5], val, settings3DS.Changed ); });
     MENU_MAKE_DISABLED  (""s);
     MENU_MAKE_HEADER2   ("SRAM (Save Data)"s);
     MENU_MAKE_PICKER    (17000, "  SRAM Auto-Save Delay"s, "Try setting to 60 seconds or Disabled this if the game saves SRAM (Save Data) to SD card too frequently."s, makeOptionsForAutoSaveSRAMDelay(), settings3DS.SRAMSaveInterval, DIALOGCOLOR_CYAN,
-                         []( int val ) { settings3DS.SRAMSaveInterval = val; });
+                         []( int val ) { CheckAndUpdate( settings3DS.SRAMSaveInterval, val, settings3DS.Changed ); });
     MENU_MAKE_CHECKBOX  (19000, "  Force SRAM Write on Pause"s, settings3DS.ForceSRAMWriteOnPause,
-                         []( int val ) { settings3DS.ForceSRAMWriteOnPause = val; });
+                         []( int val ) { CheckAndUpdate( settings3DS.ForceSRAMWriteOnPause, val, settings3DS.Changed ); });
     return items;
 };
 
@@ -502,6 +514,7 @@ bool settingsSave(bool includeGameSettings = true)
     settingsReadWriteFullListGlobal(true);
     ui3dsDrawRect(50, 140, 270, 154, 0x000000);
 
+    settings3DS.Changed = false;
     return true;
 }
 
@@ -510,6 +523,7 @@ bool settingsSave(bool includeGameSettings = true)
 //----------------------------------------------------------------------
 bool settingsLoad(bool includeGameSettings = true)
 {
+    settings3DS.Changed = false;
     bool success = settingsReadWriteFullListGlobal(false);
     if (!success)
         return false;
@@ -623,46 +637,6 @@ int fileFindLastSelectedFile(std::vector<SMenuItem>& fileMenu)
             return i;
     }
     return -1;
-}
-
-
-
-
-//----------------------------------------------------------------------
-// Copy values from menu to settings.
-//----------------------------------------------------------------------
-bool menuCopySettings(std::vector<SMenuTab>& menuTab, bool copyMenuToSettings)
-{
-#define UPDATE_SETTINGS(var, tabIndex, ID)  \
-    if (copyMenuToSettings && (var) != menu3dsGetValueByID(menuTab, tabIndex, ID)) \
-    { \
-        var = menu3dsGetValueByID(menuTab, tabIndex, ID); \
-        settingsUpdated = true; \
-    } \
-    if (!copyMenuToSettings) \
-    { \
-        menu3dsSetValueByID(menuTab, tabIndex, ID, (var)); \
-    }
-
-    bool settingsUpdated = false;
-    //UPDATE_SETTINGS(settings3DS.Font, 1, 18000);
-    //UPDATE_SETTINGS(settings3DS.ScreenStretch, 1, 11000);
-    //UPDATE_SETTINGS(settings3DS.HideUnnecessaryBottomScrText, 1, 15001);
-    //UPDATE_SETTINGS(settings3DS.MaxFrameSkips, 1, 10000);
-    //UPDATE_SETTINGS(settings3DS.ForceFrameRate, 1, 12000);
-    //UPDATE_SETTINGS(settings3DS.Turbo[0], 1, 13000);
-    //UPDATE_SETTINGS(settings3DS.Turbo[1], 1, 13001);
-    //UPDATE_SETTINGS(settings3DS.Turbo[2], 1, 13002);
-    //UPDATE_SETTINGS(settings3DS.Turbo[3], 1, 13003);
-    //UPDATE_SETTINGS(settings3DS.Turbo[4], 1, 13004);
-    //UPDATE_SETTINGS(settings3DS.Turbo[5], 1, 13005);
-    //UPDATE_SETTINGS(settings3DS.Volume, 1, 14000);
-    //UPDATE_SETTINGS(settings3DS.PaletteFix, 1, 16000);
-    //UPDATE_SETTINGS(settings3DS.AutoSavestate, 1, 19100);
-    //UPDATE_SETTINGS(settings3DS.SRAMSaveInterval, 1, 17000);
-    //UPDATE_SETTINGS(settings3DS.ForceSRAMWriteOnPause, 1, 19000);
-
-    return settingsUpdated;
 }
 
 
@@ -834,7 +808,6 @@ void menuPause()
     menu3dsAddTab(menuTab, "Select ROM", fileMenu);
     std::vector<SMenuItem>& cheatMenu = menuTab[2].MenuItems;
 
-    menuCopySettings(menuTab, false);
     menuCopyCheats(cheatMenu, false);
 
     int previousFileID = fileFindLastSelectedFile(fileMenu);
@@ -894,7 +867,7 @@ void menuPause()
                 bool loadRom = true;
 
                 // in case someone changed the AutoSavestate option while the menu was open
-                if (menuCopySettings(menuTab, true))
+                if (settings3DS.Changed)
                     settingsSave();
 
                 if (settings3DS.AutoSavestate)
@@ -1039,7 +1012,7 @@ void menuPause()
 
     // Save settings and cheats
     //
-    if (menuCopySettings(menuTab, true))
+    if (settings3DS.Changed)
         settingsSave();
     settingsUpdateAllSettings();
 

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -114,28 +114,28 @@ namespace {
 }
 
 #define MENU_MAKE_ACTION(ID, text, callback) \
-    items.emplace_back( callback, MENUITEM_ACTION, ID, text, ""s, 0 )
+    items.emplace_back( callback, MenuItemType::Action, ID, text, ""s, 0 )
 
 #define MENU_MAKE_DIALOG_ACTION(ID, text, desc) \
-    items.emplace_back( nullptr, MENUITEM_ACTION, ID, text, desc, 0 )
+    items.emplace_back( nullptr, MenuItemType::Action, ID, text, desc, 0 )
 
 #define MENU_MAKE_DISABLED(text) \
-    items.emplace_back( nullptr, MENUITEM_DISABLED, -1, text, ""s )
+    items.emplace_back( nullptr, MenuItemType::Disabled, -1, text, ""s )
 
 #define MENU_MAKE_HEADER1(text) \
-    items.emplace_back( nullptr, MENUITEM_HEADER1, -1, text, ""s )
+    items.emplace_back( nullptr, MenuItemType::Header1, -1, text, ""s )
 
 #define MENU_MAKE_HEADER2(text) \
-    items.emplace_back( nullptr, MENUITEM_HEADER2, -1, text, ""s )
+    items.emplace_back( nullptr, MenuItemType::Header2, -1, text, ""s )
 
 #define MENU_MAKE_CHECKBOX(ID, text, value, callback) \
-    items.emplace_back( callback, MENUITEM_CHECKBOX, ID, text, ""s, value )
+    items.emplace_back( callback, MenuItemType::Checkbox, ID, text, ""s, value )
 
 #define MENU_MAKE_GAUGE(ID, text, min, max, value, callback) \
-    items.emplace_back( callback, MENUITEM_GAUGE, ID, text, ""s, value, min, max )
+    items.emplace_back( callback, MenuItemType::Gauge, ID, text, ""s, value, min, max )
 
 #define MENU_MAKE_PICKER(ID, text, pickerDescription, pickerOptions, value, backColor, callback) \
-    items.emplace_back( callback, MENUITEM_PICKER, ID, text, ""s, value, 0, 0, pickerDescription, pickerOptions, backColor )
+    items.emplace_back( callback, MenuItemType::Picker, ID, text, ""s, value, 0, 0, pickerDescription, pickerOptions, backColor )
 
 
 std::vector<SMenuItem> makeEmulatorMenu() {
@@ -621,7 +621,7 @@ void fileGetAllFiles(std::vector<SMenuItem>& fileMenu, std::vector<std::string>&
     for (int i = 0; i < files.size() && i < 1000; i++)
     {
         romFileNames.emplace_back(files[i]);
-        fileMenu.emplace_back(nullptr, MENUITEM_ACTION, i, std::string(romFileNames[i]), ""s);
+        fileMenu.emplace_back(nullptr, MenuItemType::Action, i, std::string(romFileNames[i]), ""s);
     }
 }
 
@@ -648,7 +648,7 @@ bool menuCopyCheats(std::vector<SMenuItem>& cheatMenu, bool copyMenuToSettings)
     bool cheatsUpdated = false;
     for (int i = 0; (i+1) < cheatMenu.size() && i < MAX_CHEATS && i < Cheat.num_cheats; i++)
     {
-        cheatMenu[i+1].Type = MENUITEM_CHECKBOX;
+        cheatMenu[i+1].Type = MenuItemType::Checkbox;
         cheatMenu[i+1].ID = 20000 + i;
         cheatMenu[i+1].Text = Cheat.c[i].name;
 
@@ -1062,14 +1062,14 @@ void menuSetupCheats(std::vector<SMenuItem>& cheatMenu)
     {
         for (int i = 0; i < MAX_CHEATS && i < Cheat.num_cheats; i++)
         {
-            cheatMenu.emplace_back(nullptr, MENUITEM_CHECKBOX, 20000+i, std::string(Cheat.c[i].name), ""s, Cheat.c[i].enabled ? 1 : 0);
+            cheatMenu.emplace_back(nullptr, MenuItemType::Checkbox, 20000+i, std::string(Cheat.c[i].name), ""s, Cheat.c[i].enabled ? 1 : 0);
         }
     }
     else
     {
         for (int i = 0; i < 14; i++)
         {
-            cheatMenu.emplace_back(nullptr, MENUITEM_DISABLED, -2, std::string(noCheatsText[i]), ""s);
+            cheatMenu.emplace_back(nullptr, MenuItemType::Disabled, -2, std::string(noCheatsText[i]), ""s);
         }
     }
 }

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -154,8 +154,8 @@ namespace {
         items.emplace_back(callback, MenuItemType::Gauge, text, ""s, value, min, max);
     }
 
-    void AddMenuPicker(std::vector<SMenuItem>& items, const std::string& text, const std::string& description, const std::vector<SMenuItem>& options, int value, int backgroundColor, std::function<void(int)> callback) {
-        items.emplace_back(callback, MenuItemType::Picker, text, ""s, value, 0, 0, description, options, backgroundColor);
+    void AddMenuPicker(std::vector<SMenuItem>& items, const std::string& text, const std::string& description, const std::vector<SMenuItem>& options, int value, int backgroundColor, bool showSelectedOptionInMenu, std::function<void(int)> callback) {
+        items.emplace_back(callback, MenuItemType::Picker, text, ""s, value, showSelectedOptionInMenu ? 1 : 0, 0, description, options, backgroundColor);
     }
 }
 
@@ -289,7 +289,7 @@ std::vector<SMenuItem> makeEmulatorMenu(std::vector<SMenuTab>& menuTab, int& cur
         }
     }, MenuItemType::Action, "  Reset Console"s, ""s);
 
-    AddMenuPicker(items, "  Exit"s, "Leaving so soon?", makeOptionsForNoYes(), 0, DIALOGCOLOR_RED, exitEmulatorOptionSelected);
+    AddMenuPicker(items, "  Exit"s, "Leaving so soon?", makeOptionsForNoYes(), 0, DIALOGCOLOR_RED, false, exitEmulatorOptionSelected);
 
     return items;
 }
@@ -352,7 +352,7 @@ std::vector<SMenuItem> makeOptionsForInFramePaletteChanges() {
 
 std::vector<SMenuItem> makeEmulatorNewMenu() {
     std::vector<SMenuItem> items;
-    AddMenuPicker(items, "  Exit"s, "Leaving so soon?", makeOptionsForNoYes(), 0, DIALOGCOLOR_RED, exitEmulatorOptionSelected);
+    AddMenuPicker(items, "  Exit"s, "Leaving so soon?", makeOptionsForNoYes(), 0, DIALOGCOLOR_RED, false, exitEmulatorOptionSelected);
     return items;
 }
 
@@ -360,9 +360,9 @@ std::vector<SMenuItem> makeOptionMenu() {
     std::vector<SMenuItem> items;
 
     AddMenuHeader1(items, "GLOBAL SETTINGS"s);
-    AddMenuPicker(items, "  Screen Stretch"s, "How would you like the final screen to appear?"s, makeOptionsForStretch(), settings3DS.ScreenStretch, DIALOGCOLOR_CYAN,
+    AddMenuPicker(items, "  Screen Stretch"s, "How would you like the final screen to appear?"s, makeOptionsForStretch(), settings3DS.ScreenStretch, DIALOGCOLOR_CYAN, true,
                   []( int val ) { CheckAndUpdate( settings3DS.ScreenStretch, val, settings3DS.Changed ); });
-    AddMenuPicker(items, "  Font"s, "The font used for the user interface."s, makeOptionsForFont(), settings3DS.Font, DIALOGCOLOR_CYAN,
+    AddMenuPicker(items, "  Font"s, "The font used for the user interface."s, makeOptionsForFont(), settings3DS.Font, DIALOGCOLOR_CYAN, true,
                   []( int val ) { if ( CheckAndUpdate( settings3DS.Font, val, settings3DS.Changed ) ) { ui3dsSetFont(val); } });
     AddMenuCheckbox(items, "  Hide text in bottom screen"s, settings3DS.HideUnnecessaryBottomScrText,
                     []( int val ) { CheckAndUpdate( settings3DS.HideUnnecessaryBottomScrText, val, settings3DS.Changed ); });
@@ -374,11 +374,11 @@ std::vector<SMenuItem> makeOptionMenu() {
 
     AddMenuHeader1(items, "GAME-SPECIFIC SETTINGS"s);
     AddMenuHeader2(items, "Graphics"s);
-    AddMenuPicker(items, "  Frameskip"s, "Try changing this if the game runs slow. Skipping frames helps it run faster, but less smooth."s, makeOptionsForFrameskip(), settings3DS.MaxFrameSkips, DIALOGCOLOR_CYAN,
+    AddMenuPicker(items, "  Frameskip"s, "Try changing this if the game runs slow. Skipping frames helps it run faster, but less smooth."s, makeOptionsForFrameskip(), settings3DS.MaxFrameSkips, DIALOGCOLOR_CYAN, true,
                   []( int val ) { CheckAndUpdate( settings3DS.MaxFrameSkips, val, settings3DS.Changed ); });
-    AddMenuPicker(items, "  Framerate"s, "Some games run at 50 or 60 FPS by default. Override if required."s, makeOptionsForFrameRate(), settings3DS.ForceFrameRate, DIALOGCOLOR_CYAN,
+    AddMenuPicker(items, "  Framerate"s, "Some games run at 50 or 60 FPS by default. Override if required."s, makeOptionsForFrameRate(), settings3DS.ForceFrameRate, DIALOGCOLOR_CYAN, true,
                   []( int val ) { CheckAndUpdate( settings3DS.ForceFrameRate, val, settings3DS.Changed ); });
-    AddMenuPicker(items, "  In-Frame Palette Changes"s, "Try changing this if some colours in the game look off."s, makeOptionsForInFramePaletteChanges(), settings3DS.PaletteFix, DIALOGCOLOR_CYAN,
+    AddMenuPicker(items, "  In-Frame Palette Changes"s, "Try changing this if some colours in the game look off."s, makeOptionsForInFramePaletteChanges(), settings3DS.PaletteFix, DIALOGCOLOR_CYAN, true,
                   []( int val ) { CheckAndUpdate( settings3DS.PaletteFix, val, settings3DS.Changed ); });
     AddMenuDisabledOption(items, ""s);
 
@@ -396,7 +396,7 @@ std::vector<SMenuItem> makeOptionMenu() {
     AddMenuDisabledOption(items, ""s);
 
     AddMenuHeader2(items, "SRAM (Save Data)"s);
-    AddMenuPicker(items, "  SRAM Auto-Save Delay"s, "Try setting to 60 seconds or Disabled this if the game saves SRAM (Save Data) to SD card too frequently."s, makeOptionsForAutoSaveSRAMDelay(), settings3DS.SRAMSaveInterval, DIALOGCOLOR_CYAN,
+    AddMenuPicker(items, "  SRAM Auto-Save Delay"s, "Try setting to 60 seconds or Disabled this if the game saves SRAM (Save Data) to SD card too frequently."s, makeOptionsForAutoSaveSRAMDelay(), settings3DS.SRAMSaveInterval, DIALOGCOLOR_CYAN, true,
                   []( int val ) { CheckAndUpdate( settings3DS.SRAMSaveInterval, val, settings3DS.Changed ); });
     AddMenuCheckbox(items, "  Force SRAM Write on Pause"s, settings3DS.ForceSRAMWriteOnPause,
                     []( int val ) { CheckAndUpdate( settings3DS.ForceSRAMWriteOnPause, val, settings3DS.Changed ); });

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -712,6 +712,7 @@ void menuSelectFile(void)
     std::vector<SMenuTab> menuTab;
     int currentMenuTab = 0;
     bool isDialog = false;
+    SMenuTab dialogTab;
 
     gfxSetDoubleBuffering(GFX_BOTTOM, true);
     
@@ -738,7 +739,7 @@ void menuSelectFile(void)
         if (appExiting)
             return;
 
-        selection = menu3dsShowMenu(isDialog, currentMenuTab, menuTab, NULL, animateMenu);
+        selection = menu3dsShowMenu(dialogTab, isDialog, currentMenuTab, menuTab, NULL, animateMenu);
         animateMenu = false;
 
         if (selection >= 0 && selection < 1000)
@@ -771,8 +772,8 @@ void menuSelectFile(void)
         }
         else if (selection == 6001)
         {
-            int result = menu3dsShowDialog(isDialog, currentMenuTab, menuTab, "Exit",  "Leaving so soon?", DIALOGCOLOR_RED, optionsForNoYes, sizeof(optionsForNoYes) / sizeof(SMenuItem));
-            menu3dsHideDialog(isDialog, currentMenuTab, menuTab);
+            int result = menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Exit",  "Leaving so soon?", DIALOGCOLOR_RED, optionsForNoYes, sizeof(optionsForNoYes) / sizeof(SMenuItem));
+            menu3dsHideDialog(dialogTab, isDialog, currentMenuTab, menuTab);
 
             if (result == 1)
             {
@@ -785,7 +786,7 @@ void menuSelectFile(void)
     }
     while (selection == -1);
 
-    menu3dsHideMenu(isDialog, currentMenuTab, menuTab);
+    menu3dsHideMenu(dialogTab, isDialog, currentMenuTab, menuTab);
 
     emulatorLoadRom();
 }
@@ -823,6 +824,7 @@ void menuPause()
     std::vector<SMenuTab> menuTab;
     int currentMenuTab = 0;
     bool isDialog = false;
+    SMenuTab dialogTab;
 
     gfxSetDoubleBuffering(GFX_BOTTOM, true);
     
@@ -863,7 +865,7 @@ void menuPause()
             break;
         }
 
-        int selection = menu3dsShowMenu(isDialog, currentMenuTab, menuTab, menuItemChangedCallback, animateMenu);
+        int selection = menu3dsShowMenu(dialogTab, isDialog, currentMenuTab, menuTab, menuItemChangedCallback, animateMenu);
         animateMenu = false;
 
         if (selection == -1 || selection == 1000)
@@ -906,13 +908,13 @@ void menuPause()
 
                 if (settings3DS.AutoSavestate)
                 {
-                    menu3dsShowDialog(isDialog, currentMenuTab, menuTab, "Save State", "Autosaving...", DIALOGCOLOR_CYAN, NULL, 0);
+                    menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Save State", "Autosaving...", DIALOGCOLOR_CYAN, NULL, 0);
                     bool result = impl3dsSaveStateAuto();
-                    menu3dsHideDialog(isDialog, currentMenuTab, menuTab);
+                    menu3dsHideDialog(dialogTab, isDialog, currentMenuTab, menuTab);
 
                     if (!result)
                     {
-                        int choice = menu3dsShowDialog(isDialog, currentMenuTab, menuTab, "Autosave failure", "Automatic savestate writing failed.\nLoad chosen game anyway?", DIALOGCOLOR_RED, optionsForNoYes, sizeof(optionsForNoYes) / sizeof(SMenuItem));
+                        int choice = menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Autosave failure", "Automatic savestate writing failed.\nLoad chosen game anyway?", DIALOGCOLOR_RED, optionsForNoYes, sizeof(optionsForNoYes) / sizeof(SMenuItem));
                         if (choice != 1)
                             loadRom = false;
                     }
@@ -932,21 +934,21 @@ void menuPause()
             char text[200];
            
             sprintf(text, "Saving into slot %d...\nThis may take a while", slot);
-            menu3dsShowDialog(isDialog, currentMenuTab, menuTab, "Savestates", text, DIALOGCOLOR_CYAN, NULL, 0);
+            menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Savestates", text, DIALOGCOLOR_CYAN, NULL, 0);
             bool result = impl3dsSaveStateSlot(slot);
-            menu3dsHideDialog(isDialog, currentMenuTab, menuTab);
+            menu3dsHideDialog(dialogTab, isDialog, currentMenuTab, menuTab);
 
             if (result)
             {
                 sprintf(text, "Slot %d save completed.", slot);
-                result = menu3dsShowDialog(isDialog, currentMenuTab, menuTab, "Savestates", text, DIALOGCOLOR_GREEN, optionsForOk, sizeof(optionsForOk) / sizeof(SMenuItem));
-                menu3dsHideDialog(isDialog, currentMenuTab, menuTab);
+                result = menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Savestates", text, DIALOGCOLOR_GREEN, optionsForOk, sizeof(optionsForOk) / sizeof(SMenuItem));
+                menu3dsHideDialog(dialogTab, isDialog, currentMenuTab, menuTab);
             }
             else
             {
                 sprintf(text, "Oops. Unable to save slot %d!", slot);
-                result = menu3dsShowDialog(isDialog, currentMenuTab, menuTab, "Savestates", text, DIALOGCOLOR_RED, optionsForOk, sizeof(optionsForOk) / sizeof(SMenuItem));
-                menu3dsHideDialog(isDialog, currentMenuTab, menuTab);
+                result = menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Savestates", text, DIALOGCOLOR_RED, optionsForOk, sizeof(optionsForOk) / sizeof(SMenuItem));
+                menu3dsHideDialog(dialogTab, isDialog, currentMenuTab, menuTab);
             }
 
             menu3dsSetSelectedItemIndexByID(currentMenuTab, menuTab, 0, 1000);
@@ -966,13 +968,13 @@ void menuPause()
             else
             {
                 sprintf(text, "Oops. Unable to load slot %d!", slot);
-                menu3dsShowDialog(isDialog, currentMenuTab, menuTab, "Savestates", text, DIALOGCOLOR_RED, optionsForOk, sizeof(optionsForOk) / sizeof(SMenuItem));
-                menu3dsHideDialog(isDialog, currentMenuTab, menuTab);
+                menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Savestates", text, DIALOGCOLOR_RED, optionsForOk, sizeof(optionsForOk) / sizeof(SMenuItem));
+                menu3dsHideDialog(dialogTab, isDialog, currentMenuTab, menuTab);
             }
         }
         else if (selection == 4001)
         {
-            menu3dsShowDialog(isDialog, currentMenuTab, menuTab, "Screenshot", "Now taking a screenshot...\nThis may take a while.", DIALOGCOLOR_CYAN, NULL, 0);
+            menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Screenshot", "Now taking a screenshot...\nThis may take a while.", DIALOGCOLOR_CYAN, NULL, 0);
 
             char ext[256];
             const char *path = NULL;
@@ -996,25 +998,25 @@ void menuPause()
             {
                 success = menu3dsTakeScreenshot(path);
             }
-            menu3dsHideDialog(isDialog, currentMenuTab, menuTab);
+            menu3dsHideDialog(dialogTab, isDialog, currentMenuTab, menuTab);
 
             if (success)
             {
                 char text[600];
                 snprintf(text, 600, "Done! File saved to %s", path);
-                menu3dsShowDialog(isDialog, currentMenuTab, menuTab, "Screenshot", text, DIALOGCOLOR_GREEN, optionsForOk, sizeof(optionsForOk)/sizeof(SMenuItem));
-                menu3dsHideDialog(isDialog, currentMenuTab, menuTab);
+                menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Screenshot", text, DIALOGCOLOR_GREEN, optionsForOk, sizeof(optionsForOk)/sizeof(SMenuItem));
+                menu3dsHideDialog(dialogTab, isDialog, currentMenuTab, menuTab);
             }
             else 
             {
-                menu3dsShowDialog(isDialog, currentMenuTab, menuTab, "Screenshot", "Oops. Unable to take screenshot!", DIALOGCOLOR_RED, optionsForOk, sizeof(optionsForOk)/sizeof(SMenuItem));
-                menu3dsHideDialog(isDialog, currentMenuTab, menuTab);
+                menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Screenshot", "Oops. Unable to take screenshot!", DIALOGCOLOR_RED, optionsForOk, sizeof(optionsForOk)/sizeof(SMenuItem));
+                menu3dsHideDialog(dialogTab, isDialog, currentMenuTab, menuTab);
             }
         }
         else if (selection == 5001)
         {
-            int result = menu3dsShowDialog(isDialog, currentMenuTab, menuTab, "Reset Console", "Are you sure?", DIALOGCOLOR_RED, optionsForNoYes, sizeof(optionsForNoYes) / sizeof(SMenuItem));
-            menu3dsHideDialog(isDialog, currentMenuTab, menuTab);
+            int result = menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Reset Console", "Are you sure?", DIALOGCOLOR_RED, optionsForNoYes, sizeof(optionsForNoYes) / sizeof(SMenuItem));
+            menu3dsHideDialog(dialogTab, isDialog, currentMenuTab, menuTab);
 
             if (result == 1)
             {
@@ -1028,7 +1030,7 @@ void menuPause()
         }
         else if (selection == 6001)
         {
-            int result = menu3dsShowDialog(isDialog, currentMenuTab, menuTab, "Exit",  "Leaving so soon?", DIALOGCOLOR_RED, optionsForNoYes, sizeof(optionsForNoYes) / sizeof(SMenuItem));
+            int result = menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Exit",  "Leaving so soon?", DIALOGCOLOR_RED, optionsForNoYes, sizeof(optionsForNoYes) / sizeof(SMenuItem));
             if (result == 1)
             {
                 GPU3DS.emulatorState = EMUSTATE_END;
@@ -1036,13 +1038,13 @@ void menuPause()
                 break;
             }
             else
-                menu3dsHideDialog(isDialog, currentMenuTab, menuTab);
+                menu3dsHideDialog(dialogTab, isDialog, currentMenuTab, menuTab);
             
         }
 
     }
 
-    menu3dsHideMenu(isDialog, currentMenuTab, menuTab);
+    menu3dsHideMenu(dialogTab, isDialog, currentMenuTab, menuTab);
 
     // Save settings and cheats
     //

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -733,7 +733,7 @@ void emulatorLoadRom()
 //----------------------------------------------------------------------
 void fileGetAllFiles(std::vector<DirectoryEntry>& romFileNames)
 {
-    file3dsGetFiles(romFileNames, "smc,sfc,fig");
+    file3dsGetFiles(romFileNames, {"smc", "sfc", "fig"});
 }
 
 

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -125,31 +125,39 @@ namespace {
         }
         return false;
     }
+
+    void AddMenuAction(std::vector<SMenuItem>& items, const std::string& text, std::function<void(int)> callback) {
+        items.emplace_back(callback, MenuItemType::Action, text, ""s);
+    }
+
+    void AddMenuDialogOption(std::vector<SMenuItem>& items, int value, const std::string& text, const std::string& description = ""s) {
+        items.emplace_back(nullptr, MenuItemType::Action, text, description, value);
+    }
+
+    void AddMenuDisabledOption(std::vector<SMenuItem>& items, const std::string& text) {
+        items.emplace_back(nullptr, MenuItemType::Disabled, text, ""s);
+    }
+
+    void AddMenuHeader1(std::vector<SMenuItem>& items, const std::string& text) {
+        items.emplace_back(nullptr, MenuItemType::Header1, text, ""s);
+    }
+
+    void AddMenuHeader2(std::vector<SMenuItem>& items, const std::string& text) {
+        items.emplace_back(nullptr, MenuItemType::Header2, text, ""s);
+    }
+
+    void AddMenuCheckbox(std::vector<SMenuItem>& items, const std::string& text, int value, std::function<void(int)> callback) {
+        items.emplace_back(callback, MenuItemType::Checkbox, text, ""s, value);
+    }
+
+    void AddMenuGauge(std::vector<SMenuItem>& items, const std::string& text, int min, int max, int value, std::function<void(int)> callback) {
+        items.emplace_back(callback, MenuItemType::Gauge, text, ""s, value, min, max);
+    }
+
+    void AddMenuPicker(std::vector<SMenuItem>& items, const std::string& text, const std::string& description, const std::vector<SMenuItem>& options, int value, int backgroundColor, std::function<void(int)> callback) {
+        items.emplace_back(callback, MenuItemType::Picker, text, ""s, value, 0, 0, description, options, backgroundColor);
+    }
 }
-
-#define MENU_MAKE_ACTION(ID, text, callback) \
-    items.emplace_back( callback, MenuItemType::Action, text, ""s, 0 )
-
-#define MENU_MAKE_DIALOG_ACTION(value, text, desc) \
-    items.emplace_back( nullptr, MenuItemType::Action, text, desc, value )
-
-#define MENU_MAKE_DISABLED(text) \
-    items.emplace_back( nullptr, MenuItemType::Disabled, text, ""s )
-
-#define MENU_MAKE_HEADER1(text) \
-    items.emplace_back( nullptr, MenuItemType::Header1, text, ""s )
-
-#define MENU_MAKE_HEADER2(text) \
-    items.emplace_back( nullptr, MenuItemType::Header2, text, ""s )
-
-#define MENU_MAKE_CHECKBOX(ID, text, value, callback) \
-    items.emplace_back( callback, MenuItemType::Checkbox, text, ""s, value )
-
-#define MENU_MAKE_GAUGE(ID, text, min, max, value, callback) \
-    items.emplace_back( callback, MenuItemType::Gauge, text, ""s, value, min, max )
-
-#define MENU_MAKE_PICKER(ID, text, pickerDescription, pickerOptions, value, backColor, callback) \
-    items.emplace_back( callback, MenuItemType::Picker, text, ""s, value, 0, 0, pickerDescription, pickerOptions, backColor )
 
 void exitEmulatorOptionSelected( int val ) {
     if ( val == 1 ) {
@@ -160,26 +168,26 @@ void exitEmulatorOptionSelected( int val ) {
 
 std::vector<SMenuItem> makeOptionsForNoYes() {
     std::vector<SMenuItem> items;
-    MENU_MAKE_DIALOG_ACTION(0, "No"s, ""s);
-    MENU_MAKE_DIALOG_ACTION(1, "Yes"s, ""s);
+    AddMenuDialogOption(items, 0, "No"s, ""s);
+    AddMenuDialogOption(items, 1, "Yes"s, ""s);
     return items;
 }
 
 std::vector<SMenuItem> makeOptionsForOk() {
     std::vector<SMenuItem> items;
-    MENU_MAKE_DIALOG_ACTION(0, "OK"s, ""s);
+    AddMenuDialogOption(items, 0, "OK"s, ""s);
     return items;
 }
 
 std::vector<SMenuItem> makeEmulatorMenu(std::vector<SMenuTab>& menuTab, int& currentMenuTab, bool& closeMenu) {
     std::vector<SMenuItem> items;
-    MENU_MAKE_HEADER2   ("Resume"s);
+    AddMenuHeader2(items, "Resume"s);
     items.emplace_back([&closeMenu](int val) {
         closeMenu = true;
-    }, MenuItemType::Action, "  Resume Game"s, ""s, 0);
-    MENU_MAKE_HEADER2   (""s);
+    }, MenuItemType::Action, "  Resume Game"s, ""s);
+    AddMenuHeader2(items, ""s);
 
-    MENU_MAKE_HEADER2   ("Savestates"s);
+    AddMenuHeader2(items, "Savestates"s);
     for (int slot = 1; slot <= 5; ++slot) {
         std::ostringstream optionText;
         optionText << "  Save Slot #" << slot;
@@ -202,9 +210,9 @@ std::vector<SMenuItem> makeEmulatorMenu(std::vector<SMenuTab>& menuTab, int& cur
                 menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Savestate failure", oss.str(), DIALOGCOLOR_RED, makeOptionsForOk());
                 menu3dsHideDialog(dialogTab, isDialog, currentMenuTab, menuTab);
             }
-        }, MenuItemType::Action, optionText.str(), ""s, 0);
+        }, MenuItemType::Action, optionText.str(), ""s);
     }
-    MENU_MAKE_HEADER2   (""s);
+    AddMenuHeader2(items, ""s);
     
     for (int slot = 1; slot <= 5; ++slot) {
         std::ostringstream optionText;
@@ -221,12 +229,11 @@ std::vector<SMenuItem> makeEmulatorMenu(std::vector<SMenuTab>& menuTab, int& cur
             } else {
                 closeMenu = true;
             }
-        }, MenuItemType::Action, optionText.str(), ""s, 0);
+        }, MenuItemType::Action, optionText.str(), ""s);
     }
-    MENU_MAKE_HEADER2   (""s);
+    AddMenuHeader2(items, ""s);
 
-    MENU_MAKE_HEADER2   ("Others"s);
-
+    AddMenuHeader2(items, "Others"s);
     items.emplace_back([&menuTab, &currentMenuTab](int val) {
         SMenuTab dialogTab;
         bool isDialog = false;
@@ -268,7 +275,7 @@ std::vector<SMenuItem> makeEmulatorMenu(std::vector<SMenuTab>& menuTab, int& cur
             menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, "Screenshot", "Oops. Unable to take screenshot!", DIALOGCOLOR_RED, makeOptionsForOk());
             menu3dsHideDialog(dialogTab, isDialog, currentMenuTab, menuTab);
         }
-    }, MenuItemType::Action, "  Take Screenshot"s, ""s, 0);
+    }, MenuItemType::Action, "  Take Screenshot"s, ""s);
 
     items.emplace_back([&menuTab, &currentMenuTab, &closeMenu](int val) {
         SMenuTab dialogTab;
@@ -280,114 +287,119 @@ std::vector<SMenuItem> makeEmulatorMenu(std::vector<SMenuTab>& menuTab, int& cur
             impl3dsResetConsole();
             closeMenu = true;
         }
-    }, MenuItemType::Action, "  Reset Console"s, ""s, 0);
+    }, MenuItemType::Action, "  Reset Console"s, ""s);
 
-    MENU_MAKE_PICKER    (6001, "  Exit"s, "Leaving so soon?", makeOptionsForNoYes(), 0, DIALOGCOLOR_RED, exitEmulatorOptionSelected);
+    AddMenuPicker(items, "  Exit"s, "Leaving so soon?", makeOptionsForNoYes(), 0, DIALOGCOLOR_RED, exitEmulatorOptionSelected);
 
     return items;
 }
 
 std::vector<SMenuItem> makeOptionsForFont() {
     std::vector<SMenuItem> items;
-    MENU_MAKE_DIALOG_ACTION (0, "Tempesta"s,              ""s);
-    MENU_MAKE_DIALOG_ACTION (1, "Ronda"s,              ""s);
-    MENU_MAKE_DIALOG_ACTION (2, "Arial"s,                 ""s);
+    AddMenuDialogOption(items, 0, "Tempesta"s, ""s);
+    AddMenuDialogOption(items, 1, "Ronda"s,    ""s);
+    AddMenuDialogOption(items, 2, "Arial"s,    ""s);
     return items;
 }
 
 std::vector<SMenuItem> makeOptionsForStretch() {
     std::vector<SMenuItem> items;
-    MENU_MAKE_DIALOG_ACTION (0, "No Stretch"s,              "'Pixel Perfect'"s);
-    MENU_MAKE_DIALOG_ACTION (7, "Expand to Fit"s,           "'Pixel Perfect' fit"s);
-    MENU_MAKE_DIALOG_ACTION (6, "TV-style"s,                "Stretch width only to 292px"s);
-    MENU_MAKE_DIALOG_ACTION (5, "4:3"s,                     "Stretch width only"s);
-    MENU_MAKE_DIALOG_ACTION (1, "4:3 Fit"s,                 "Stretch to 320x240"s);
-    MENU_MAKE_DIALOG_ACTION (2, "Fullscreen"s,              "Stretch to 400x240"s);
-    MENU_MAKE_DIALOG_ACTION (3, "Cropped 4:3 Fit"s,         "Crop & Stretch to 320x240"s);
-    MENU_MAKE_DIALOG_ACTION (4, "Cropped Fullscreen"s,      "Crop & Stretch to 400x240"s);
+    AddMenuDialogOption(items, 0, "No Stretch"s,              "'Pixel Perfect'"s);
+    AddMenuDialogOption(items, 7, "Expand to Fit"s,           "'Pixel Perfect' fit"s);
+    AddMenuDialogOption(items, 6, "TV-style"s,                "Stretch width only to 292px"s);
+    AddMenuDialogOption(items, 5, "4:3"s,                     "Stretch width only"s);
+    AddMenuDialogOption(items, 1, "4:3 Fit"s,                 "Stretch to 320x240"s);
+    AddMenuDialogOption(items, 2, "Fullscreen"s,              "Stretch to 400x240"s);
+    AddMenuDialogOption(items, 3, "Cropped 4:3 Fit"s,         "Crop & Stretch to 320x240"s);
+    AddMenuDialogOption(items, 4, "Cropped Fullscreen"s,      "Crop & Stretch to 400x240"s);
     return items;
 }
 
 std::vector<SMenuItem> makeOptionsForFrameskip() {
     std::vector<SMenuItem> items;
-    MENU_MAKE_DIALOG_ACTION (0, "Disabled"s,                ""s);
-    MENU_MAKE_DIALOG_ACTION (1, "Enabled (max 1 frame)"s,   ""s);
-    MENU_MAKE_DIALOG_ACTION (2, "Enabled (max 2 frames)"s,   ""s);
-    MENU_MAKE_DIALOG_ACTION (3, "Enabled (max 3 frames)"s,   ""s);
-    MENU_MAKE_DIALOG_ACTION (4, "Enabled (max 4 frames)"s,   ""s);
+    AddMenuDialogOption(items, 0, "Disabled"s,                ""s);
+    AddMenuDialogOption(items, 1, "Enabled (max 1 frame)"s,   ""s);
+    AddMenuDialogOption(items, 2, "Enabled (max 2 frames)"s,   ""s);
+    AddMenuDialogOption(items, 3, "Enabled (max 3 frames)"s,   ""s);
+    AddMenuDialogOption(items, 4, "Enabled (max 4 frames)"s,   ""s);
     return items;
 };
 
 std::vector<SMenuItem> makeOptionsForFrameRate() {
     std::vector<SMenuItem> items;
-    MENU_MAKE_DIALOG_ACTION (0, "Default based on ROM region"s,    ""s);
-    MENU_MAKE_DIALOG_ACTION (1, "50 FPS"s,                  ""s);
-    MENU_MAKE_DIALOG_ACTION (2, "60 FPS"s,                  ""s);
+    AddMenuDialogOption(items, 0, "Default based on ROM region"s,    ""s);
+    AddMenuDialogOption(items, 1, "50 FPS"s,                  ""s);
+    AddMenuDialogOption(items, 2, "60 FPS"s,                  ""s);
     return items;
 };
 
 std::vector<SMenuItem> makeOptionsForAutoSaveSRAMDelay() {
     std::vector<SMenuItem> items;
-    MENU_MAKE_DIALOG_ACTION (1, "1 second"s,    ""s);
-    MENU_MAKE_DIALOG_ACTION (2, "10 seconds"s,  ""s);
-    MENU_MAKE_DIALOG_ACTION (3, "60 seconds"s,  ""s);
-    MENU_MAKE_DIALOG_ACTION (4, "Disabled"s,    "Touch bottom screen to save"s);
+    AddMenuDialogOption(items, 1, "1 second"s,    ""s);
+    AddMenuDialogOption(items, 2, "10 seconds"s,  ""s);
+    AddMenuDialogOption(items, 3, "60 seconds"s,  ""s);
+    AddMenuDialogOption(items, 4, "Disabled"s,    "Touch bottom screen to save"s);
     return items;
 };
 
 std::vector<SMenuItem> makeOptionsForInFramePaletteChanges() {
     std::vector<SMenuItem> items;
-    MENU_MAKE_DIALOG_ACTION (1, "Enabled"s,         "Best (not 100% accurate); slower"s);
-    MENU_MAKE_DIALOG_ACTION (2, "Disabled Style 1"s,"Faster than \"Enabled\""s);
-    MENU_MAKE_DIALOG_ACTION (3, "Disabled Style 2"s,"Faster than \"Enabled\""s);
+    AddMenuDialogOption(items, 1, "Enabled"s,          "Best (not 100% accurate); slower"s);
+    AddMenuDialogOption(items, 2, "Disabled Style 1"s, "Faster than \"Enabled\""s);
+    AddMenuDialogOption(items, 3, "Disabled Style 2"s, "Faster than \"Enabled\""s);
     return items;
 };
 
 std::vector<SMenuItem> makeEmulatorNewMenu() {
     std::vector<SMenuItem> items;
-    MENU_MAKE_PICKER(6001, "  Exit"s, "Leaving so soon?", makeOptionsForNoYes(), 0, DIALOGCOLOR_RED, exitEmulatorOptionSelected);
+    AddMenuPicker(items, "  Exit"s, "Leaving so soon?", makeOptionsForNoYes(), 0, DIALOGCOLOR_RED, exitEmulatorOptionSelected);
     return items;
 }
 
 std::vector<SMenuItem> makeOptionMenu() {
     std::vector<SMenuItem> items;
-    MENU_MAKE_HEADER1   ("GLOBAL SETTINGS"s);
-    MENU_MAKE_PICKER    (11000, "  Screen Stretch"s, "How would you like the final screen to appear?"s, makeOptionsForStretch(), settings3DS.ScreenStretch, DIALOGCOLOR_CYAN,
-                         []( int val ) { CheckAndUpdate( settings3DS.ScreenStretch, val, settings3DS.Changed ); });
-    MENU_MAKE_PICKER    (18000, "  Font"s, "The font used for the user interface."s, makeOptionsForFont(), settings3DS.Font, DIALOGCOLOR_CYAN,
-                         []( int val ) { if ( CheckAndUpdate( settings3DS.Font, val, settings3DS.Changed ) ) { ui3dsSetFont(val); } });
-    MENU_MAKE_CHECKBOX  (15001, "  Hide text in bottom screen"s, settings3DS.HideUnnecessaryBottomScrText,
-                         []( int val ) { CheckAndUpdate( settings3DS.HideUnnecessaryBottomScrText, val, settings3DS.Changed ); });
-    MENU_MAKE_DISABLED  (""s);
-    MENU_MAKE_CHECKBOX  (19100, "  Automatically save state on exit and load state on start"s, settings3DS.AutoSavestate,
+
+    AddMenuHeader1(items, "GLOBAL SETTINGS"s);
+    AddMenuPicker(items, "  Screen Stretch"s, "How would you like the final screen to appear?"s, makeOptionsForStretch(), settings3DS.ScreenStretch, DIALOGCOLOR_CYAN,
+                  []( int val ) { CheckAndUpdate( settings3DS.ScreenStretch, val, settings3DS.Changed ); });
+    AddMenuPicker(items, "  Font"s, "The font used for the user interface."s, makeOptionsForFont(), settings3DS.Font, DIALOGCOLOR_CYAN,
+                  []( int val ) { if ( CheckAndUpdate( settings3DS.Font, val, settings3DS.Changed ) ) { ui3dsSetFont(val); } });
+    AddMenuCheckbox(items, "  Hide text in bottom screen"s, settings3DS.HideUnnecessaryBottomScrText,
+                    []( int val ) { CheckAndUpdate( settings3DS.HideUnnecessaryBottomScrText, val, settings3DS.Changed ); });
+    AddMenuDisabledOption(items, ""s);
+
+    AddMenuCheckbox(items, "  Automatically save state on exit and load state on start"s, settings3DS.AutoSavestate,
                          []( int val ) { CheckAndUpdate( settings3DS.AutoSavestate, val, settings3DS.Changed ); });
-    MENU_MAKE_DISABLED  (""s);
-    MENU_MAKE_HEADER1   ("GAME-SPECIFIC SETTINGS"s);
-    MENU_MAKE_HEADER2   ("Graphics"s);
-    MENU_MAKE_PICKER    (10000, "  Frameskip"s, "Try changing this if the game runs slow. Skipping frames help it run faster but less smooth."s, makeOptionsForFrameskip(), settings3DS.MaxFrameSkips, DIALOGCOLOR_CYAN,
-                         []( int val ) { CheckAndUpdate( settings3DS.MaxFrameSkips, val, settings3DS.Changed ); });
-    MENU_MAKE_PICKER    (12000, "  Framerate"s, "Some games run at 50 or 60 FPS by default. Override if required."s, makeOptionsForFrameRate(), settings3DS.ForceFrameRate, DIALOGCOLOR_CYAN,
-                         []( int val ) { CheckAndUpdate( settings3DS.ForceFrameRate, val, settings3DS.Changed ); });
-    MENU_MAKE_PICKER    (16000, "  In-Frame Palette Changes"s, "Try changing this if some colours in the game look off."s, makeOptionsForInFramePaletteChanges(), settings3DS.PaletteFix, DIALOGCOLOR_CYAN,
-                         []( int val ) { CheckAndUpdate( settings3DS.PaletteFix, val, settings3DS.Changed ); });
-    MENU_MAKE_DISABLED  (""s);
-    MENU_MAKE_HEADER2   ("Audio"s);
-    MENU_MAKE_GAUGE     (14000, "  Volume Amplification"s, 0, 8, settings3DS.Volume,
-                         []( int val ) { CheckAndUpdate( settings3DS.Volume, val, settings3DS.Changed ); });
-    MENU_MAKE_DISABLED  (""s);
-    MENU_MAKE_HEADER2   ("Turbo (Auto-Fire) Buttons"s);
-    MENU_MAKE_CHECKBOX  (13000, "  Button A"s, settings3DS.Turbo[0], []( int val ) { CheckAndUpdate( settings3DS.Turbo[0], val, settings3DS.Changed ); });
-    MENU_MAKE_CHECKBOX  (13001, "  Button B"s, settings3DS.Turbo[1], []( int val ) { CheckAndUpdate( settings3DS.Turbo[1], val, settings3DS.Changed ); });
-    MENU_MAKE_CHECKBOX  (13002, "  Button X"s, settings3DS.Turbo[2], []( int val ) { CheckAndUpdate( settings3DS.Turbo[2], val, settings3DS.Changed ); });
-    MENU_MAKE_CHECKBOX  (13003, "  Button Y"s, settings3DS.Turbo[3], []( int val ) { CheckAndUpdate( settings3DS.Turbo[3], val, settings3DS.Changed ); });
-    MENU_MAKE_CHECKBOX  (13004, "  Button L"s, settings3DS.Turbo[4], []( int val ) { CheckAndUpdate( settings3DS.Turbo[4], val, settings3DS.Changed ); });
-    MENU_MAKE_CHECKBOX  (13005, "  Button R"s, settings3DS.Turbo[5], []( int val ) { CheckAndUpdate( settings3DS.Turbo[5], val, settings3DS.Changed ); });
-    MENU_MAKE_DISABLED  (""s);
-    MENU_MAKE_HEADER2   ("SRAM (Save Data)"s);
-    MENU_MAKE_PICKER    (17000, "  SRAM Auto-Save Delay"s, "Try setting to 60 seconds or Disabled this if the game saves SRAM (Save Data) to SD card too frequently."s, makeOptionsForAutoSaveSRAMDelay(), settings3DS.SRAMSaveInterval, DIALOGCOLOR_CYAN,
-                         []( int val ) { CheckAndUpdate( settings3DS.SRAMSaveInterval, val, settings3DS.Changed ); });
-    MENU_MAKE_CHECKBOX  (19000, "  Force SRAM Write on Pause"s, settings3DS.ForceSRAMWriteOnPause,
-                         []( int val ) { CheckAndUpdate( settings3DS.ForceSRAMWriteOnPause, val, settings3DS.Changed ); });
+    AddMenuDisabledOption(items, ""s);
+
+    AddMenuHeader1(items, "GAME-SPECIFIC SETTINGS"s);
+    AddMenuHeader2(items, "Graphics"s);
+    AddMenuPicker(items, "  Frameskip"s, "Try changing this if the game runs slow. Skipping frames helps it run faster, but less smooth."s, makeOptionsForFrameskip(), settings3DS.MaxFrameSkips, DIALOGCOLOR_CYAN,
+                  []( int val ) { CheckAndUpdate( settings3DS.MaxFrameSkips, val, settings3DS.Changed ); });
+    AddMenuPicker(items, "  Framerate"s, "Some games run at 50 or 60 FPS by default. Override if required."s, makeOptionsForFrameRate(), settings3DS.ForceFrameRate, DIALOGCOLOR_CYAN,
+                  []( int val ) { CheckAndUpdate( settings3DS.ForceFrameRate, val, settings3DS.Changed ); });
+    AddMenuPicker(items, "  In-Frame Palette Changes"s, "Try changing this if some colours in the game look off."s, makeOptionsForInFramePaletteChanges(), settings3DS.PaletteFix, DIALOGCOLOR_CYAN,
+                  []( int val ) { CheckAndUpdate( settings3DS.PaletteFix, val, settings3DS.Changed ); });
+    AddMenuDisabledOption(items, ""s);
+
+    AddMenuHeader2(items, "Audio"s);
+    AddMenuGauge(items, "  Volume Amplification"s, 0, 8, settings3DS.Volume,
+                 []( int val ) { CheckAndUpdate( settings3DS.Volume, val, settings3DS.Changed ); });
+    AddMenuDisabledOption(items, ""s);
+    AddMenuHeader2(items, "Turbo (Auto-Fire) Buttons"s);
+    AddMenuCheckbox(items, "  Button A"s, settings3DS.Turbo[0], []( int val ) { CheckAndUpdate( settings3DS.Turbo[0], val, settings3DS.Changed ); });
+    AddMenuCheckbox(items, "  Button B"s, settings3DS.Turbo[1], []( int val ) { CheckAndUpdate( settings3DS.Turbo[1], val, settings3DS.Changed ); });
+    AddMenuCheckbox(items, "  Button X"s, settings3DS.Turbo[2], []( int val ) { CheckAndUpdate( settings3DS.Turbo[2], val, settings3DS.Changed ); });
+    AddMenuCheckbox(items, "  Button Y"s, settings3DS.Turbo[3], []( int val ) { CheckAndUpdate( settings3DS.Turbo[3], val, settings3DS.Changed ); });
+    AddMenuCheckbox(items, "  Button L"s, settings3DS.Turbo[4], []( int val ) { CheckAndUpdate( settings3DS.Turbo[4], val, settings3DS.Changed ); });
+    AddMenuCheckbox(items, "  Button R"s, settings3DS.Turbo[5], []( int val ) { CheckAndUpdate( settings3DS.Turbo[5], val, settings3DS.Changed ); });
+    AddMenuDisabledOption(items, ""s);
+
+    AddMenuHeader2(items, "SRAM (Save Data)"s);
+    AddMenuPicker(items, "  SRAM Auto-Save Delay"s, "Try setting to 60 seconds or Disabled this if the game saves SRAM (Save Data) to SD card too frequently."s, makeOptionsForAutoSaveSRAMDelay(), settings3DS.SRAMSaveInterval, DIALOGCOLOR_CYAN,
+                  []( int val ) { CheckAndUpdate( settings3DS.SRAMSaveInterval, val, settings3DS.Changed ); });
+    AddMenuCheckbox(items, "  Force SRAM Write on Pause"s, settings3DS.ForceSRAMWriteOnPause,
+                    []( int val ) { CheckAndUpdate( settings3DS.ForceSRAMWriteOnPause, val, settings3DS.Changed ); });
     return items;
 };
 
@@ -395,7 +407,7 @@ void menuSetupCheats(std::vector<SMenuItem>& cheatMenu);
 
 std::vector<SMenuItem> makeCheatMenu() {
     std::vector<SMenuItem> items;
-    MENU_MAKE_HEADER2   ("Cheats"s);
+    AddMenuHeader2(items, "Cheats"s);
     menuSetupCheats(items);
     return items;
 };

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -687,16 +687,16 @@ void menuSelectFile(void)
     gfxSetDoubleBuffering(GFX_BOTTOM, true);
 
     fileGetAllFiles(fileMenu, romFileNames);
-    int previousFileID = fileFindLastSelectedFile(fileMenu);
     menuTab.clear();
-    currentMenuTab = 0;
     menu3dsAddTab(menuTab, "Emulator", makeEmulatorNewMenu());
     menu3dsAddTab(menuTab, "Select ROM", fileMenu);
     menuTab[0].SubTitle.clear();
     menuTab[1].SubTitle.assign(file3dsGetCurrentDir());
     currentMenuTab = 1;
-    if (previousFileID >= 0)
-        menu3dsSetSelectedItemIndexByID(currentMenuTab, menuTab, 1, previousFileID);
+
+    int previousFileID = fileFindLastSelectedFile(fileMenu);
+    menu3dsSetSelectedItemByIndex(menuTab[1], previousFileID);
+
     menu3dsSetTransferGameScreen(false);
 
     bool animateMenu = true;
@@ -810,14 +810,14 @@ void menuPause()
 
     menuCopyCheats(cheatMenu, false);
 
-    int previousFileID = fileFindLastSelectedFile(fileMenu);
     menuTab[0].SubTitle.clear();
     menuTab[1].SubTitle.clear();
     menuTab[2].SubTitle.clear();
     menuTab[3].SubTitle.assign(file3dsGetCurrentDir());
-    if (previousFileID >= 0)
-        menu3dsSetSelectedItemIndexByID(currentMenuTab, menuTab, 3, previousFileID);
-    currentMenuTab = 0;
+
+    int previousFileID = fileFindLastSelectedFile(fileMenu);
+    menu3dsSetSelectedItemByIndex(menuTab[3], previousFileID);
+
     menu3dsSetTransferGameScreen(true);
 
     bool animateMenu = true;
@@ -915,7 +915,7 @@ void menuPause()
                 menu3dsHideDialog(dialogTab, isDialog, currentMenuTab, menuTab);
             }
 
-            menu3dsSetSelectedItemIndexByID(currentMenuTab, menuTab, 0, 1000);
+            // TODO: Select 'resume' option again?
         }
         else if (selection >= 3001 && selection <= 3010)
         {

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -54,7 +54,6 @@ int frameCount60 = 60;
 u64 frameCountTick = 0;
 int framesSkippedCount = 0;
 char romFileName[_MAX_PATH];
-char romFileNameFullPath[_MAX_PATH];
 char romFileNameLastSelected[_MAX_PATH];
 
 
@@ -575,8 +574,9 @@ void emulatorLoadRom()
     gfxSetDoubleBuffering(GFX_BOTTOM, false);
     consoleClear();
     settingsSave(false);
-    snprintf(romFileNameFullPath, _MAX_PATH, "%s%s", file3dsGetCurrentDir(), romFileName);
 
+    char romFileNameFullPath[_MAX_PATH];
+    snprintf(romFileNameFullPath, _MAX_PATH, "%s%s", file3dsGetCurrentDir(), romFileName);
     impl3dsLoadROM(romFileNameFullPath);
 
     GPU3DS.emulatorState = EMUSTATE_EMULATE;

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -811,11 +811,11 @@ void setupBootupMenu(std::vector<SMenuTab>& menuTab, std::vector<DirectoryEntry>
         fileGetAllFiles(romFileNames);
         fillFileMenuFromFileNames(fileMenu, romFileNames, selectedDirectoryEntry);
         menu3dsAddTab(menuTab, "Select ROM", fileMenu);
+        menuTab.back().SubTitle.assign(file3dsGetCurrentDir());
         if (selectPreviousFile) {
             int previousFileID = fileFindLastSelectedFile(menuTab.back().MenuItems);
             menu3dsSetSelectedItemByIndex(menuTab.back(), previousFileID);
         }
-        menuTab.back().SubTitle.assign(file3dsGetCurrentDir());
     }
 }
 
@@ -884,11 +884,11 @@ void setupPauseMenu(std::vector<SMenuTab>& menuTab, std::vector<DirectoryEntry>&
         fileGetAllFiles(romFileNames);
         fillFileMenuFromFileNames(fileMenu, romFileNames, selectedDirectoryEntry);
         menu3dsAddTab(menuTab, "Select ROM", fileMenu);
+        menuTab.back().SubTitle.assign(file3dsGetCurrentDir());
         if (selectPreviousFile) {
             int previousFileID = fileFindLastSelectedFile(menuTab.back().MenuItems);
             menu3dsSetSelectedItemByIndex(menuTab.back(), previousFileID);
         }
-        menuTab.back().SubTitle.assign(file3dsGetCurrentDir());
     }
 }
 

--- a/source/3dsmenu.cpp
+++ b/source/3dsmenu.cpp
@@ -98,12 +98,11 @@ void menu3dsDrawItems(
     char selectedTextBuffer[512];
     
     // Display the subtitle
-    if (currentTab->SubTitle[0])
+    if (!currentTab->SubTitle.empty())
     {
         maxItems--;
-        snprintf (menuTextBuffer, 511, "%s", currentTab->SubTitle);
         ui3dsDrawStringWithNoWrapping(20, menuStartY, 300, menuStartY + fontHeight, 
-            subtitleTextColor, HALIGN_LEFT, menuTextBuffer);
+            subtitleTextColor, HALIGN_LEFT, currentTab->SubTitle.c_str());
         menuStartY += fontHeight;
     }
 
@@ -515,7 +514,7 @@ int menu3dsMenuSelectItem(bool& isDialog, int& currentMenuTab, std::vector<SMenu
         if (isDialog)
             maxItems = DIALOG_HEIGHT;
 
-        if (currentTab->SubTitle[0])
+        if (!currentTab->SubTitle.empty())
         {
             maxItems--;
         }
@@ -714,17 +713,6 @@ void menu3dsAddTab(std::vector<SMenuTab>& menuTab, char *title, SMenuItem *menuI
     }
 }
 
-
-
-void menu3dsSetTabSubTitle(std::vector<SMenuTab>& menuTab, int tabIndex, char *subtitle)
-{
-    SMenuTab *currentTab = &menuTab[tabIndex];
-
-    currentTab->SubTitle[0] = 0;
-    if (subtitle != NULL)
-        strncpy(currentTab->SubTitle, subtitle, 255);
-}
-
 void menu3dsSetSelectedItemIndexByID(int& currentMenuTab, std::vector<SMenuTab>& menuTab, int tabIndex, int ID)
 {
     currentMenuTab = tabIndex;
@@ -732,7 +720,7 @@ void menu3dsSetSelectedItemIndexByID(int& currentMenuTab, std::vector<SMenuTab>&
     SMenuTab *currentTab = &menuTab[tabIndex];
 
     int maxItems = MENU_HEIGHT;
-    if (currentTab->SubTitle[0])
+    if (!currentTab->SubTitle.empty())
         maxItems--;
 
     for (int i = 0; i < currentTab->ItemCount; i++)

--- a/source/3dsmenu.cpp
+++ b/source/3dsmenu.cpp
@@ -91,9 +91,6 @@ void menu3dsDrawItems(
     int subtitleTextColor)
 {
     int fontHeight = 13;
-    char gauge[52];
-    char menuTextBuffer[512];
-    char selectedTextBuffer[512];
     
     // Display the subtitle
     if (!currentTab->SubTitle.empty())
@@ -114,11 +111,6 @@ void menu3dsDrawItems(
     {
         int y = line * fontHeight + menuStartY;
 
-        if (currentTab->MenuItems[i].Text == NULL)
-            snprintf (menuTextBuffer, 511, "");
-        else
-            snprintf (menuTextBuffer, 511, "%s", currentTab->MenuItems[i].Text);
-
         // Draw the selected background 
         //
         if (currentTab->SelectedItemIndex == i)
@@ -129,33 +121,32 @@ void menu3dsDrawItems(
         if (currentTab->MenuItems[i].Type == MENUITEM_HEADER1)
         {
             color = headerItemTextColor;
-            ui3dsDrawStringWithNoWrapping(horizontalPadding, y, 320 - horizontalPadding, y + fontHeight, color, HALIGN_LEFT, menuTextBuffer);
+            ui3dsDrawStringWithNoWrapping(horizontalPadding, y, 320 - horizontalPadding, y + fontHeight, color, HALIGN_LEFT, currentTab->MenuItems[i].Text.c_str());
             ui3dsDrawRect(horizontalPadding, y + fontHeight - 1, 320 - horizontalPadding, y + fontHeight, color);
         }
         else if (currentTab->MenuItems[i].Type == MENUITEM_HEADER2)
         {
             color = headerItemTextColor;
-            ui3dsDrawStringWithNoWrapping(horizontalPadding, y, 320 - horizontalPadding, y + fontHeight, color, HALIGN_LEFT, menuTextBuffer);
+            ui3dsDrawStringWithNoWrapping(horizontalPadding, y, 320 - horizontalPadding, y + fontHeight, color, HALIGN_LEFT, currentTab->MenuItems[i].Text.c_str());
         }
         else if (currentTab->MenuItems[i].Type == MENUITEM_DISABLED)
         {
             color = disabledItemTextColor;
-            ui3dsDrawStringWithNoWrapping(horizontalPadding, y, 320 - horizontalPadding, y + fontHeight, color, HALIGN_LEFT, menuTextBuffer);
+            ui3dsDrawStringWithNoWrapping(horizontalPadding, y, 320 - horizontalPadding, y + fontHeight, color, HALIGN_LEFT, currentTab->MenuItems[i].Text.c_str());
         }
         else if (currentTab->MenuItems[i].Type == MENUITEM_ACTION)
         {
             color = normalItemTextColor;
             if (currentTab->SelectedItemIndex == i)
                 color = selectedItemTextColor;
-            ui3dsDrawStringWithNoWrapping(horizontalPadding, y, 320 - horizontalPadding, y + fontHeight, color, HALIGN_LEFT, menuTextBuffer);
+            ui3dsDrawStringWithNoWrapping(horizontalPadding, y, 320 - horizontalPadding, y + fontHeight, color, HALIGN_LEFT, currentTab->MenuItems[i].Text.c_str());
 
             color = normalItemDescriptionTextColor;
             if (currentTab->SelectedItemIndex == i)
                 color = selectedItemDescriptionTextColor;
-            if (currentTab->MenuItems[i].Description != NULL)
+            if (!currentTab->MenuItems[i].Description.empty())
             {
-                snprintf(menuTextBuffer, 511, "%s", currentTab->MenuItems[i].Description);
-                ui3dsDrawStringWithNoWrapping(horizontalPadding, y, 320 - horizontalPadding, y + fontHeight, color, HALIGN_RIGHT, menuTextBuffer);
+                ui3dsDrawStringWithNoWrapping(horizontalPadding, y, 320 - horizontalPadding, y + fontHeight, color, HALIGN_RIGHT, currentTab->MenuItems[i].Description.c_str());
             }
         }
         else if (currentTab->MenuItems[i].Type == MENUITEM_CHECKBOX)
@@ -165,20 +156,18 @@ void menu3dsDrawItems(
                 color = disabledItemTextColor;
                 if (currentTab->SelectedItemIndex == i)
                     color = selectedItemTextColor;
-                ui3dsDrawStringWithNoWrapping(horizontalPadding, y, 320 - horizontalPadding, y + fontHeight, color, HALIGN_LEFT, menuTextBuffer);
+                ui3dsDrawStringWithNoWrapping(horizontalPadding, y, 320 - horizontalPadding, y + fontHeight, color, HALIGN_LEFT, currentTab->MenuItems[i].Text.c_str());
 
-                snprintf(menuTextBuffer, 511, "\xfe");
-                ui3dsDrawStringWithNoWrapping(280, y, 320 - horizontalPadding, y + fontHeight, color, HALIGN_RIGHT, menuTextBuffer);
+                ui3dsDrawStringWithNoWrapping(280, y, 320 - horizontalPadding, y + fontHeight, color, HALIGN_RIGHT, "\xfe");
             }
             else
             {
                 color = normalItemTextColor;
                 if (currentTab->SelectedItemIndex == i)
                     color = selectedItemTextColor;
-                ui3dsDrawStringWithNoWrapping(horizontalPadding, y, 320 - horizontalPadding, y + fontHeight, color, HALIGN_LEFT, menuTextBuffer);
+                ui3dsDrawStringWithNoWrapping(horizontalPadding, y, 320 - horizontalPadding, y + fontHeight, color, HALIGN_LEFT, currentTab->MenuItems[i].Text.c_str());
 
-                snprintf(menuTextBuffer, 511, "\xfd");
-                ui3dsDrawStringWithNoWrapping(280, y, 320 - horizontalPadding, y + fontHeight, color, HALIGN_RIGHT, menuTextBuffer);
+                ui3dsDrawStringWithNoWrapping(280, y, 320 - horizontalPadding, y + fontHeight, color, HALIGN_RIGHT, "\xfd");
             }
         }
         else if (currentTab->MenuItems[i].Type == MENUITEM_GAUGE)
@@ -187,12 +176,13 @@ void menu3dsDrawItems(
             if (currentTab->SelectedItemIndex == i)
                 color = selectedItemTextColor;
 
-            ui3dsDrawStringWithNoWrapping(horizontalPadding, y, 320 - horizontalPadding, y + fontHeight, color, HALIGN_LEFT, menuTextBuffer);
+            ui3dsDrawStringWithNoWrapping(horizontalPadding, y, 320 - horizontalPadding, y + fontHeight, color, HALIGN_LEFT, currentTab->MenuItems[i].Text.c_str());
 
-            int max = 40;
+            const int max = 40;
             int diff = currentTab->MenuItems[i].GaugeMaxValue - currentTab->MenuItems[i].GaugeMinValue;
             int pos = (currentTab->MenuItems[i].Value - currentTab->MenuItems[i].GaugeMinValue) * (max - 1) / diff;
 
+            char gauge[max+1];
             for (int j = 0; j < max; j++)
                 gauge[j] = (j == pos) ? '\xfa' : '\xfb';
             gauge[max] = 0;
@@ -204,20 +194,23 @@ void menu3dsDrawItems(
             if (currentTab->SelectedItemIndex == i)
                 color = selectedItemTextColor;
 
-            ui3dsDrawStringWithNoWrapping(horizontalPadding, y, 160, y + fontHeight, color, HALIGN_LEFT, menuTextBuffer);
+            ui3dsDrawStringWithNoWrapping(horizontalPadding, y, 160, y + fontHeight, color, HALIGN_LEFT, currentTab->MenuItems[i].Text.c_str());
 
-            snprintf(selectedTextBuffer, 511, "");
-            if (currentTab->MenuItems[i].PickerItems != NULL)
+            if (!currentTab->MenuItems[i].PickerItems.empty())
             {
-                for (int j = 0; j < currentTab->MenuItems[i].PickerItemCount; j++)
+                int selectedIndex = -1;
+                for (int j = 0; j < currentTab->MenuItems[i].PickerItems.size(); j++)
                 {
-                    SMenuItem *pickerItems = (SMenuItem *)currentTab->MenuItems[i].PickerItems;
+                    std::vector<SMenuItem>& pickerItems = currentTab->MenuItems[i].PickerItems;
                     if (pickerItems[j].ID == currentTab->MenuItems[i].Value)
                     {
-                        snprintf(selectedTextBuffer, 511, "%s", pickerItems[j].Text);
+                        selectedIndex = j;
                     }
                 }
-                ui3dsDrawStringWithNoWrapping(160, y, 320 - horizontalPadding, y + fontHeight, color, HALIGN_RIGHT, selectedTextBuffer);
+                if (selectedIndex > -1)
+                {
+                    ui3dsDrawStringWithNoWrapping(160, y, 320 - horizontalPadding, y + fontHeight, color, HALIGN_RIGHT, currentTab->MenuItems[i].PickerItems[selectedIndex].Text.c_str());
+                }
             }
         }
 
@@ -590,12 +583,11 @@ int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuT
             }
             if (currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MENUITEM_PICKER)
             {
-                snprintf(menuTextBuffer, 511, "%s", currentTab->MenuItems[currentTab->SelectedItemIndex].Text);
+                snprintf(menuTextBuffer, 511, "%s", currentTab->MenuItems[currentTab->SelectedItemIndex].Text.c_str());
                 int resultValue = menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, menuTextBuffer,
                     currentTab->MenuItems[currentTab->SelectedItemIndex].PickerDescription,
                     currentTab->MenuItems[currentTab->SelectedItemIndex].PickerBackColor,
-                    (SMenuItem *)currentTab->MenuItems[currentTab->SelectedItemIndex].PickerItems,
-                    currentTab->MenuItems[currentTab->SelectedItemIndex].PickerItemCount,
+                    currentTab->MenuItems[currentTab->SelectedItemIndex].PickerItems,
                     currentTab->MenuItems[currentTab->SelectedItemIndex].Value
                     );
                 if (resultValue != -1)
@@ -694,18 +686,18 @@ int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuT
 
 
 
-void menu3dsAddTab(std::vector<SMenuTab>& menuTab, char *title, SMenuItem *menuItems, int itemCount)
+void menu3dsAddTab(std::vector<SMenuTab>& menuTab, char *title, const std::vector<SMenuItem>& menuItems)
 {
     menuTab.emplace_back();
     SMenuTab *currentTab = &menuTab.back();
 
     currentTab->SetTitle(title);
     currentTab->MenuItems = menuItems;
-    currentTab->ItemCount = itemCount;
+    currentTab->ItemCount = static_cast<int>(menuItems.size());
 
     currentTab->FirstItemIndex = 0;
     currentTab->SelectedItemIndex = 0;
-    for (int i = 0; i < itemCount; i++)
+    for (int i = 0; i < currentTab->ItemCount; i++)
     {
         if (menuItems[i].ID > -1)
         {
@@ -802,7 +794,7 @@ void menu3dsHideMenu(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, s
     ui3dsSetTranslate(0, 0);
 }
 
-int menu3dsShowDialog(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab, char *title, char *dialogText, int newDialogBackColor, SMenuItem *menuItems, int itemCount, int selectedID)
+int menu3dsShowDialog(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab, const std::string& title, const std::string& dialogText, int newDialogBackColor, const std::vector<SMenuItem>& menuItems, int selectedID)
 {
     SMenuTab *currentTab = &dialogTab;
 
@@ -811,12 +803,12 @@ int menu3dsShowDialog(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, 
     currentTab->SetTitle(title);
     currentTab->DialogText.assign(dialogText);
     currentTab->MenuItems = menuItems;
-    currentTab->ItemCount = itemCount;
+    currentTab->ItemCount = static_cast<int>(menuItems.size());
 
     currentTab->FirstItemIndex = 0;
     currentTab->SelectedItemIndex = 0;
 
-    for (int i = 0; i < itemCount; i++)
+    for (int i = 0; i < currentTab->ItemCount; i++)
     {
         if ((selectedID == -1 && menuItems[i].ID > -1) || 
             menuItems[i].ID == selectedID)
@@ -845,7 +837,7 @@ int menu3dsShowDialog(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, 
 
     // Execute the dialog and return result.
     //
-    if (itemCount > 0)
+    if (currentTab->ItemCount > 0)
     {
         int result = menu3dsMenuSelectItem(dialogTab, isDialog, currentMenuTab, menuTab, NULL);
 

--- a/source/3dsmenu.cpp
+++ b/source/3dsmenu.cpp
@@ -706,60 +706,24 @@ void menu3dsAddTab(std::vector<SMenuTab>& menuTab, char *title, const std::vecto
     }
 }
 
-void menu3dsSetSelectedItemIndexByID(int& currentMenuTab, std::vector<SMenuTab>& menuTab, int tabIndex, int ID)
+void menu3dsSetSelectedItemByIndex(SMenuTab& tab, int index)
 {
-    currentMenuTab = tabIndex;
+    if (index >= 0 && index < tab.MenuItems.size()) {
+        tab.SelectedItemIndex = index;
 
-    SMenuTab *currentTab = &menuTab[tabIndex];
+        int maxItems = MENU_HEIGHT;
+        if (!tab.SubTitle.empty()) {
+            maxItems--;
+        }
 
-    int maxItems = MENU_HEIGHT;
-    if (!currentTab->SubTitle.empty())
-        maxItems--;
-
-    for (int i = 0; i < currentTab->ItemCount; i++)
-    {
-        if (currentTab->MenuItems[i].ID == ID)
-        {
-            currentTab->SelectedItemIndex = i;
-
-            if (currentTab->SelectedItemIndex < currentTab->FirstItemIndex)
-                currentTab->FirstItemIndex = currentTab->SelectedItemIndex;
-            if (currentTab->SelectedItemIndex >= currentTab->FirstItemIndex + maxItems)
-                currentTab->FirstItemIndex = currentTab->SelectedItemIndex - maxItems + 1;
-
-            break;
+        if (tab.SelectedItemIndex < tab.FirstItemIndex) {
+            tab.FirstItemIndex = tab.SelectedItemIndex;
+        }
+        
+        if (tab.SelectedItemIndex >= tab.FirstItemIndex + maxItems) {
+            tab.FirstItemIndex = tab.SelectedItemIndex - maxItems + 1;
         }
     }
-}
-
-
-void menu3dsSetValueByID(std::vector<SMenuTab>& menuTab, int tabIndex, int ID, int value)
-{
-    SMenuTab *currentTab = &menuTab[tabIndex];
-
-    for (int i = 0; i < currentTab->ItemCount; i++)
-    {
-        if (currentTab->MenuItems[i].ID == ID)
-        {
-            currentTab->MenuItems[i].SetValue(value);
-            break;
-        }
-    }
-}
-
-
-int menu3dsGetValueByID(std::vector<SMenuTab>& menuTab, int tabIndex, int ID)
-{
-    SMenuTab *currentTab = &menuTab[tabIndex];
-
-    for (int i = 0; i < currentTab->ItemCount; i++)
-    {
-        if (currentTab->MenuItems[i].ID == ID)
-        {
-            return currentTab->MenuItems[i].Value;
-        }
-    }
-    return -1;
 }
 
 int menu3dsShowMenu(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab, bool animateMenu)

--- a/source/3dsmenu.cpp
+++ b/source/3dsmenu.cpp
@@ -21,7 +21,6 @@
 #define ANIMATE_TAB_STEPS 3
 
 
-SMenuTab            dialogTab;
 int menuTabCount;
 
 bool                transferGameScreen = false;
@@ -360,7 +359,7 @@ int dialogItemTextColor = 0xffffff;
 int dialogSelectedItemTextColor = 0xffffff;
 int dialogSelectedItemBackColor = 0x000000;
 
-void menu3dsDrawDialog()
+void menu3dsDrawDialog(SMenuTab& dialogTab)
 {
     // Dialog's Background
     int dialogBackColor2 = ui3dsApplyAlphaToColor(dialogBackColor, 0.9f);
@@ -392,7 +391,7 @@ void menu3dsDrawDialog()
 }
 
 
-void menu3dsDrawEverything(bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab, int menuFrame = 0, int menuItemsFrame = 0, int dialogFrame = 0)
+void menu3dsDrawEverything(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab, int menuFrame = 0, int menuItemsFrame = 0, int dialogFrame = 0)
 {
     if (!isDialog)
     {
@@ -416,14 +415,14 @@ void menu3dsDrawEverything(bool& isDialog, int& currentMenuTab, std::vector<SMen
 
         ui3dsSetViewport(0, 0, 320, 240);
         ui3dsSetTranslate(0, y);
-        menu3dsDrawDialog();
+        menu3dsDrawDialog(dialogTab);
         ui3dsSetTranslate(0, 0);
     }
     swapBuffer = true;
 }
 
 
-SMenuTab *menu3dsAnimateTab(bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab, int direction)
+SMenuTab *menu3dsAnimateTab(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab, int direction)
 {
     SMenuTab *currentTab = &menuTab[currentMenuTab];
 
@@ -432,7 +431,7 @@ SMenuTab *menu3dsAnimateTab(bool& isDialog, int& currentMenuTab, std::vector<SMe
         for (int i = 1; i <= ANIMATE_TAB_STEPS; i++)
         {
             aptMainLoop();
-            menu3dsDrawEverything(isDialog, currentMenuTab, menuTab, 0, i, 0);
+            menu3dsDrawEverything(dialogTab, isDialog, currentMenuTab, menuTab, 0, i, 0);
             menu3dsSwapBuffersAndWaitForVBlank();
         }
 
@@ -444,7 +443,7 @@ SMenuTab *menu3dsAnimateTab(bool& isDialog, int& currentMenuTab, std::vector<SMe
         for (int i = -ANIMATE_TAB_STEPS; i <= 0; i++)
         {
             aptMainLoop();
-            menu3dsDrawEverything(isDialog, currentMenuTab, menuTab, 0, i, 0);
+            menu3dsDrawEverything(dialogTab, isDialog, currentMenuTab, menuTab, 0, i, 0);
             menu3dsSwapBuffersAndWaitForVBlank();
         }
     }
@@ -453,7 +452,7 @@ SMenuTab *menu3dsAnimateTab(bool& isDialog, int& currentMenuTab, std::vector<SMe
         for (int i = -1; i >= -ANIMATE_TAB_STEPS; i--)
         {
             aptMainLoop();
-            menu3dsDrawEverything(isDialog, currentMenuTab, menuTab, 0, i, 0);
+            menu3dsDrawEverything(dialogTab, isDialog, currentMenuTab, menuTab, 0, i, 0);
             menu3dsSwapBuffersAndWaitForVBlank();
         }
 
@@ -465,7 +464,7 @@ SMenuTab *menu3dsAnimateTab(bool& isDialog, int& currentMenuTab, std::vector<SMe
         for (int i = ANIMATE_TAB_STEPS; i >= 0; i--)
         {
             aptMainLoop();
-            menu3dsDrawEverything(isDialog, currentMenuTab, menuTab, 0, i, 0);
+            menu3dsDrawEverything(dialogTab, isDialog, currentMenuTab, menuTab, 0, i, 0);
             menu3dsSwapBuffersAndWaitForVBlank();
         }
     }
@@ -480,7 +479,7 @@ static u32 thisKeysHeld = 0;
 // Displays the menu and allows the user to select from
 // a list of choices.
 //
-int menu3dsMenuSelectItem(bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab, void (*itemChangedCallback)(int ID, int value))
+int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab, void (*itemChangedCallback)(int ID, int value))
 {
     int framesDKeyHeld = 0;
     int returnResult = -1;
@@ -495,7 +494,7 @@ int menu3dsMenuSelectItem(bool& isDialog, int& currentMenuTab, std::vector<SMenu
     for (int i = 0; i < 2; i ++)
     {
         aptMainLoop();
-        menu3dsDrawEverything(isDialog, currentMenuTab, menuTab);
+        menu3dsDrawEverything(dialogTab, isDialog, currentMenuTab, menuTab);
         menu3dsSwapBuffersAndWaitForVBlank();
 
         hidScanInput();
@@ -547,11 +546,11 @@ int menu3dsMenuSelectItem(bool& isDialog, int& currentMenuTab, std::vector<SMenu
                     {
                         currentTab->MenuItems[currentTab->SelectedItemIndex].Value ++ ;
                     }
-                    menu3dsDrawEverything(isDialog, currentMenuTab, menuTab);
+                    menu3dsDrawEverything(dialogTab, isDialog, currentMenuTab, menuTab);
                 }
                 else
                 {
-                    currentTab = menu3dsAnimateTab(isDialog, currentMenuTab, menuTab, +1);
+                    currentTab = menu3dsAnimateTab(dialogTab, isDialog, currentMenuTab, menuTab, +1);
                 }
             }
         }
@@ -568,11 +567,11 @@ int menu3dsMenuSelectItem(bool& isDialog, int& currentMenuTab, std::vector<SMenu
                     {
                         currentTab->MenuItems[currentTab->SelectedItemIndex].Value -- ;
                     }
-                    menu3dsDrawEverything(isDialog, currentMenuTab, menuTab);
+                    menu3dsDrawEverything(dialogTab, isDialog, currentMenuTab, menuTab);
                 }
                 else
                 {
-                    currentTab = menu3dsAnimateTab(isDialog, currentMenuTab, menuTab, -1);
+                    currentTab = menu3dsAnimateTab(dialogTab, isDialog, currentMenuTab, menuTab, -1);
                 }
             }
         }
@@ -589,12 +588,12 @@ int menu3dsMenuSelectItem(bool& isDialog, int& currentMenuTab, std::vector<SMenu
                     currentTab->MenuItems[currentTab->SelectedItemIndex].Value = 1;
                 else
                     currentTab->MenuItems[currentTab->SelectedItemIndex].Value = 0;
-                menu3dsDrawEverything(isDialog, currentMenuTab, menuTab);
+                menu3dsDrawEverything(dialogTab, isDialog, currentMenuTab, menuTab);
             }
             if (currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MENUITEM_PICKER)
             {
                 snprintf(menuTextBuffer, 511, "%s", currentTab->MenuItems[currentTab->SelectedItemIndex].Text);
-                int resultValue = menu3dsShowDialog(isDialog, currentMenuTab, menuTab, menuTextBuffer,
+                int resultValue = menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, menuTextBuffer,
                     currentTab->MenuItems[currentTab->SelectedItemIndex].PickerDescription,
                     currentTab->MenuItems[currentTab->SelectedItemIndex].PickerBackColor,
                     (SMenuItem *)currentTab->MenuItems[currentTab->SelectedItemIndex].PickerItems,
@@ -608,8 +607,8 @@ int menu3dsMenuSelectItem(bool& isDialog, int& currentMenuTab, std::vector<SMenu
                     
                     currentTab->MenuItems[currentTab->SelectedItemIndex].Value = resultValue;
                 }
-                menu3dsDrawEverything(isDialog, currentMenuTab, menuTab);
-                menu3dsHideDialog(isDialog, currentMenuTab, menuTab);
+                menu3dsDrawEverything(dialogTab, isDialog, currentMenuTab, menuTab);
+                menu3dsHideDialog(dialogTab, isDialog, currentMenuTab, menuTab);
 
 
             }
@@ -648,7 +647,7 @@ int menu3dsMenuSelectItem(bool& isDialog, int& currentMenuTab, std::vector<SMenu
             if (currentTab->SelectedItemIndex >= currentTab->FirstItemIndex + maxItems)
                 currentTab->FirstItemIndex = currentTab->SelectedItemIndex - maxItems + 1;
 
-            menu3dsDrawEverything(isDialog, currentMenuTab, menuTab);
+            menu3dsDrawEverything(dialogTab, isDialog, currentMenuTab, menuTab);
 
         }
         if (keysDown & KEY_DOWN || ((thisKeysHeld & KEY_DOWN) && (framesDKeyHeld > 30) && (framesDKeyHeld % 2 == 0)))
@@ -685,7 +684,7 @@ int menu3dsMenuSelectItem(bool& isDialog, int& currentMenuTab, std::vector<SMenu
             if (currentTab->SelectedItemIndex >= currentTab->FirstItemIndex + maxItems)
                 currentTab->FirstItemIndex = currentTab->SelectedItemIndex - maxItems + 1;
 
-            menu3dsDrawEverything(isDialog, currentMenuTab, menuTab);
+            menu3dsDrawEverything(dialogTab, isDialog, currentMenuTab, menuTab);
         }
 
         menu3dsSwapBuffersAndWaitForVBlank();
@@ -776,7 +775,7 @@ int menu3dsGetValueByID(std::vector<SMenuTab>& menuTab, int tabIndex, int ID)
     return -1;
 }
 
-int menu3dsShowMenu(bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab, void (*itemChangedCallback)(int ID, int value), bool animateMenu)
+int menu3dsShowMenu(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab, void (*itemChangedCallback)(int ID, int value), bool animateMenu)
 {
     isDialog = false;
 
@@ -785,27 +784,27 @@ int menu3dsShowMenu(bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& 
         for (int f = 8; f >= 0; f--)
         {
             aptMainLoop();
-            menu3dsDrawEverything(isDialog, currentMenuTab, menuTab, f, 0, 0);
+            menu3dsDrawEverything(dialogTab, isDialog, currentMenuTab, menuTab, f, 0, 0);
             menu3dsSwapBuffersAndWaitForVBlank();  
         }
     }
 
-    return menu3dsMenuSelectItem(isDialog, currentMenuTab, menuTab, itemChangedCallback);
+    return menu3dsMenuSelectItem(dialogTab, isDialog, currentMenuTab, menuTab, itemChangedCallback);
 
 }
 
-void menu3dsHideMenu(bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab)
+void menu3dsHideMenu(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab)
 {
     for (int f = 0; f <= 8; f++)
     {
         aptMainLoop();
-        menu3dsDrawEverything(isDialog, currentMenuTab, menuTab, f, 0, 0);
+        menu3dsDrawEverything(dialogTab, isDialog, currentMenuTab, menuTab, f, 0, 0);
         menu3dsSwapBuffersAndWaitForVBlank();  
     }    
     ui3dsSetTranslate(0, 0);
 }
 
-int menu3dsShowDialog(bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab, char *title, char *dialogText, int newDialogBackColor, SMenuItem *menuItems, int itemCount, int selectedID)
+int menu3dsShowDialog(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab, char *title, char *dialogText, int newDialogBackColor, SMenuItem *menuItems, int itemCount, int selectedID)
 {
     SMenuTab *currentTab = &dialogTab;
 
@@ -834,7 +833,7 @@ int menu3dsShowDialog(bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>
     // fade the dialog fade in
     //
     aptMainLoop();
-    menu3dsDrawEverything(isDialog, currentMenuTab, menuTab);
+    menu3dsDrawEverything(dialogTab, isDialog, currentMenuTab, menuTab);
     menu3dsSwapBuffersAndWaitForVBlank();  
     //ui3dsCopyFromFrameBuffer(savedBuffer);
 
@@ -842,7 +841,7 @@ int menu3dsShowDialog(bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>
     for (int f = 8; f >= 0; f--)
     {
         aptMainLoop();
-        menu3dsDrawEverything(isDialog, currentMenuTab, menuTab, 0, 0, f);
+        menu3dsDrawEverything(dialogTab, isDialog, currentMenuTab, menuTab, 0, 0, f);
         menu3dsSwapBuffersAndWaitForVBlank();  
     }
 
@@ -850,7 +849,7 @@ int menu3dsShowDialog(bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>
     //
     if (itemCount > 0)
     {
-        int result = menu3dsMenuSelectItem(isDialog, currentMenuTab, menuTab, NULL);
+        int result = menu3dsMenuSelectItem(dialogTab, isDialog, currentMenuTab, menuTab, NULL);
 
         return result;
     }
@@ -858,14 +857,14 @@ int menu3dsShowDialog(bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>
 }
 
 
-void menu3dsHideDialog(bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab)
+void menu3dsHideDialog(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab)
 {
     // fade the dialog out
     //
     for (int f = 0; f <= 8; f++)
     {
         aptMainLoop();
-        menu3dsDrawEverything(isDialog, currentMenuTab, menuTab, 0, 0, f);
+        menu3dsDrawEverything(dialogTab, isDialog, currentMenuTab, menuTab, 0, 0, f);
         menu3dsSwapBuffersAndWaitForVBlank();    
     }
 
@@ -874,7 +873,7 @@ void menu3dsHideDialog(bool& isDialog, int& currentMenuTab, std::vector<SMenuTab
     // draw the updated menu
     //
     aptMainLoop();
-    menu3dsDrawEverything(isDialog, currentMenuTab, menuTab);
+    menu3dsDrawEverything(dialogTab, isDialog, currentMenuTab, menuTab);
     menu3dsSwapBuffersAndWaitForVBlank();  
     
 }

--- a/source/3dsmenu.cpp
+++ b/source/3dsmenu.cpp
@@ -571,6 +571,7 @@ int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuT
             if (currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MenuItemType::Action)
             {
                 returnResult = currentTab->MenuItems[currentTab->SelectedItemIndex].ID;
+                currentTab->MenuItems[currentTab->SelectedItemIndex].SetValue(1);
                 break;
             }
             if (currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MenuItemType::Checkbox)

--- a/source/3dsmenu.cpp
+++ b/source/3dsmenu.cpp
@@ -107,7 +107,7 @@ void menu3dsDrawItems(
     // Draw all the individual items
     //
     for (int i = currentTab->FirstItemIndex;
-        i < currentTab->ItemCount && i < currentTab->FirstItemIndex + maxItems; i++)
+        i < currentTab->MenuItems.size() && i < currentTab->FirstItemIndex + maxItems; i++)
     {
         int y = line * fontHeight + menuStartY;
 
@@ -227,7 +227,7 @@ void menu3dsDrawItems(
 
     // Draw the "down arrow" to indicate more options available at bottom
     //
-    if (currentTab->FirstItemIndex + maxItems < currentTab->ItemCount)
+    if (currentTab->FirstItemIndex + maxItems < currentTab->MenuItems.size())
     {
         ui3dsDrawStringWithNoWrapping(320 - horizontalPadding, menuStartY + (maxItems - 1) * fontHeight, 320, menuStartY + maxItems * fontHeight, disabledItemTextColor, HALIGN_CENTER, "\xf9");
     }
@@ -617,7 +617,7 @@ int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuT
                     currentTab->SelectedItemIndex--;
                     if (currentTab->SelectedItemIndex < 0)
                     {
-                        currentTab->SelectedItemIndex = currentTab->ItemCount - 1;
+                        currentTab->SelectedItemIndex = currentTab->MenuItems.size() - 1;
                     }
                 }
                 moveCursorTimes++;
@@ -627,7 +627,7 @@ int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuT
                 currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MenuItemType::Header1 ||
                 currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MenuItemType::Header2
                 ) &&
-                moveCursorTimes < currentTab->ItemCount);
+                moveCursorTimes < currentTab->MenuItems.size());
 
             if (currentTab->SelectedItemIndex < currentTab->FirstItemIndex)
                 currentTab->FirstItemIndex = currentTab->SelectedItemIndex;
@@ -645,13 +645,13 @@ int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuT
                 if (thisKeysHeld & KEY_X)
                 {
                     currentTab->SelectedItemIndex += 15;
-                    if (currentTab->SelectedItemIndex >= currentTab->ItemCount)
-                        currentTab->SelectedItemIndex = currentTab->ItemCount - 1;
+                    if (currentTab->SelectedItemIndex >= currentTab->MenuItems.size())
+                        currentTab->SelectedItemIndex = currentTab->MenuItems.size() - 1;
                 }
                 else
                 {
                     currentTab->SelectedItemIndex++;
-                    if (currentTab->SelectedItemIndex >= currentTab->ItemCount)
+                    if (currentTab->SelectedItemIndex >= currentTab->MenuItems.size())
                     {
                         currentTab->SelectedItemIndex = 0;
                         currentTab->FirstItemIndex = 0;
@@ -664,7 +664,7 @@ int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuT
                 currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MenuItemType::Header1 ||
                 currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MenuItemType::Header2
                 ) &&
-                moveCursorTimes < currentTab->ItemCount);
+                moveCursorTimes < currentTab->MenuItems.size());
 
             if (currentTab->SelectedItemIndex < currentTab->FirstItemIndex)
                 currentTab->FirstItemIndex = currentTab->SelectedItemIndex;
@@ -690,11 +690,10 @@ void menu3dsAddTab(std::vector<SMenuTab>& menuTab, char *title, const std::vecto
 
     currentTab->SetTitle(title);
     currentTab->MenuItems = menuItems;
-    currentTab->ItemCount = static_cast<int>(menuItems.size());
 
     currentTab->FirstItemIndex = 0;
     currentTab->SelectedItemIndex = 0;
-    for (int i = 0; i < currentTab->ItemCount; i++)
+    for (int i = 0; i < currentTab->MenuItems.size(); i++)
     {
         if (menuItems[i].ID > -1)
         {
@@ -764,12 +763,11 @@ int menu3dsShowDialog(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, 
     currentTab->SetTitle(title);
     currentTab->DialogText.assign(dialogText);
     currentTab->MenuItems = menuItems;
-    currentTab->ItemCount = static_cast<int>(menuItems.size());
 
     currentTab->FirstItemIndex = 0;
     currentTab->SelectedItemIndex = 0;
 
-    for (int i = 0; i < currentTab->ItemCount; i++)
+    for (int i = 0; i < currentTab->MenuItems.size(); i++)
     {
         if ((selectedID == -1 && menuItems[i].ID > -1) || 
             menuItems[i].ID == selectedID)
@@ -798,7 +796,7 @@ int menu3dsShowDialog(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, 
 
     // Execute the dialog and return result.
     //
-    if (currentTab->ItemCount > 0)
+    if (currentTab->MenuItems.size() > 0)
     {
         int result = menu3dsMenuSelectItem(dialogTab, isDialog, currentMenuTab, menuTab);
 

--- a/source/3dsmenu.cpp
+++ b/source/3dsmenu.cpp
@@ -630,11 +630,7 @@ int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuT
                 ) &&
                 moveCursorTimes < currentTab->MenuItems.size());
 
-            if (currentTab->SelectedItemIndex < currentTab->FirstItemIndex)
-                currentTab->FirstItemIndex = currentTab->SelectedItemIndex;
-            if (currentTab->SelectedItemIndex >= currentTab->FirstItemIndex + maxItems)
-                currentTab->FirstItemIndex = currentTab->SelectedItemIndex - maxItems + 1;
-
+            currentTab->MakeSureSelectionIsOnScreen(maxItems);
             menu3dsDrawEverything(dialogTab, isDialog, currentMenuTab, menuTab);
 
         }
@@ -667,11 +663,7 @@ int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuT
                 ) &&
                 moveCursorTimes < currentTab->MenuItems.size());
 
-            if (currentTab->SelectedItemIndex < currentTab->FirstItemIndex)
-                currentTab->FirstItemIndex = currentTab->SelectedItemIndex;
-            if (currentTab->SelectedItemIndex >= currentTab->FirstItemIndex + maxItems)
-                currentTab->FirstItemIndex = currentTab->SelectedItemIndex - maxItems + 1;
-
+            currentTab->MakeSureSelectionIsOnScreen(maxItems);
             menu3dsDrawEverything(dialogTab, isDialog, currentMenuTab, menuTab);
         }
 
@@ -699,8 +691,7 @@ void menu3dsAddTab(std::vector<SMenuTab>& menuTab, char *title, const std::vecto
         if (menuItems[i].IsHighlightable())
         {
             currentTab->SelectedItemIndex = i;
-            if (currentTab->SelectedItemIndex >= currentTab->FirstItemIndex + MENU_HEIGHT)
-                currentTab->FirstItemIndex = currentTab->SelectedItemIndex - MENU_HEIGHT + 1;
+            currentTab->MakeSureSelectionIsOnScreen(MENU_HEIGHT);
             break;
         }
     }
@@ -715,14 +706,7 @@ void menu3dsSetSelectedItemByIndex(SMenuTab& tab, int index)
         if (!tab.SubTitle.empty()) {
             maxItems--;
         }
-
-        if (tab.SelectedItemIndex < tab.FirstItemIndex) {
-            tab.FirstItemIndex = tab.SelectedItemIndex;
-        }
-        
-        if (tab.SelectedItemIndex >= tab.FirstItemIndex + maxItems) {
-            tab.FirstItemIndex = tab.SelectedItemIndex - maxItems + 1;
-        }
+        tab.MakeSureSelectionIsOnScreen(maxItems);
     }
 }
 
@@ -774,8 +758,7 @@ int menu3dsShowDialog(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, 
             menuItems[i].Value == selectedID)
         {
             currentTab->SelectedItemIndex = i;
-            if (currentTab->SelectedItemIndex >= currentTab->FirstItemIndex + DIALOG_HEIGHT)
-                currentTab->FirstItemIndex = currentTab->SelectedItemIndex - DIALOG_HEIGHT + 1;
+            currentTab->MakeSureSelectionIsOnScreen(DIALOG_HEIGHT);
             break;
         }
     }

--- a/source/3dsmenu.cpp
+++ b/source/3dsmenu.cpp
@@ -196,7 +196,7 @@ void menu3dsDrawItems(
 
             ui3dsDrawStringWithNoWrapping(horizontalPadding, y, 160, y + fontHeight, color, HALIGN_LEFT, currentTab->MenuItems[i].Text.c_str());
 
-            if (!currentTab->MenuItems[i].PickerItems.empty())
+            if (!currentTab->MenuItems[i].PickerItems.empty() && currentTab->MenuItems[i].GaugeMinValue)
             {
                 int selectedIndex = -1;
                 for (int j = 0; j < currentTab->MenuItems[i].PickerItems.size(); j++)

--- a/source/3dsmenu.cpp
+++ b/source/3dsmenu.cpp
@@ -279,7 +279,7 @@ void menu3dsDrawMenu(std::vector<SMenuTab>& menuTab, int& currentMenuTab, int me
         int yCurrentTabBoxTop = 21;
         int yCurrentTabBoxBottom = 24;
 
-        ui3dsDrawStringWithNoWrapping(xLeft, yTextTop, xRight, yCurrentTabBoxTop, color, HALIGN_CENTER, menuTab[i].Title);
+        ui3dsDrawStringWithNoWrapping(xLeft, yTextTop, xRight, yCurrentTabBoxTop, color, HALIGN_CENTER, menuTab[i].Title.c_str());
 
         if (i == currentMenuTab) {
             ui3dsDrawRect(xLeft, yCurrentTabBoxTop, xRight, yCurrentTabBoxBottom, 0xFFFFFF);
@@ -367,22 +367,12 @@ void menu3dsDrawDialog()
     ui3dsDrawRect(0, 0, 320, 75, dialogBackColor2);
     ui3dsDrawRect(0, 75, 320, 160, dialogBackColor);
 
-    // Left trim the dialog title
-    int len = strlen(dialogTab.Title);
-    int startChar = 0;
-    for (int i = 0; i < len; i++)
-        if (dialogTab.Title[i] != ' ')
-        {
-            startChar = i;
-            break;
-        }
-
     // Draw the dialog's title and descriptive text
     int dialogTitleTextColor = 
         ui3dsApplyAlphaToColor(dialogBackColor, 0.5f) + 
         ui3dsApplyAlphaToColor(dialogTextColor, 0.5f);
-    ui3dsDrawStringWithNoWrapping(30, 10, 290, 25, dialogTitleTextColor, HALIGN_LEFT, &dialogTab.Title[startChar]);
-    ui3dsDrawStringWithWrapping(30, 30, 290, 70, dialogTextColor, HALIGN_LEFT, dialogTab.DialogText);
+    ui3dsDrawStringWithNoWrapping(30, 10, 290, 25, dialogTitleTextColor, HALIGN_LEFT, dialogTab.Title.c_str());
+    ui3dsDrawStringWithWrapping(30, 30, 290, 70, dialogTextColor, HALIGN_LEFT, dialogTab.DialogText.c_str());
 
     // Draw the selectable items.
     int dialogItemDescriptionTextColor = dialogTitleTextColor;
@@ -712,7 +702,7 @@ void menu3dsAddTab(std::vector<SMenuTab>& menuTab, char *title, SMenuItem *menuI
     menuTab.emplace_back();
     SMenuTab *currentTab = &menuTab.back();
 
-    currentTab->Title = title;
+    currentTab->SetTitle(title);
     currentTab->MenuItems = menuItems;
     currentTab->ItemCount = itemCount;
 
@@ -821,8 +811,8 @@ int menu3dsShowDialog(bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>
 
     dialogBackColor = newDialogBackColor;
 
-    currentTab->Title = title;
-    currentTab->DialogText = dialogText;
+    currentTab->SetTitle(title);
+    currentTab->DialogText.assign(dialogText);
     currentTab->MenuItems = menuItems;
     currentTab->ItemCount = itemCount;
 

--- a/source/3dsmenu.cpp
+++ b/source/3dsmenu.cpp
@@ -21,8 +21,6 @@
 #define ANIMATE_TAB_STEPS 3
 
 
-int menuTabCount;
-
 bool                transferGameScreen = false;
 int                 transferGameScreenCount = 0;
 

--- a/source/3dsmenu.cpp
+++ b/source/3dsmenu.cpp
@@ -1,4 +1,5 @@
 #include <array>
+#include <cmath>
 #include <cstring>
 #include <string.h>
 #include <stdio.h>
@@ -261,12 +262,28 @@ void menu3dsDrawMenu(std::vector<SMenuTab>& menuTab, int& currentMenuTab, int me
     //
     for (int i = 0; i < static_cast<int>(menuTab.size()); i++)
     {
-        int color = i == currentMenuTab ? 0xFFFFFF : 0x90CAF9 ;
-        ui3dsDrawStringWithNoWrapping(i * 75 + 10, 6, (i+1)*75 + 10, 21, color, HALIGN_CENTER, 
-            menuTab[i].Title);
+        int color = i == currentMenuTab ? 0xFFFFFF : 0x90CAF9;
 
-        if (i == currentMenuTab)
-            ui3dsDrawRect(i * 75 + 10, 21, (i+1)*75 + 10, 24, 0xFFFFFF);
+        int offsetLeft = 10;
+        int offsetRight = 10;
+
+        int availableSpace = 320 - ( offsetLeft + offsetRight );
+        int pixelPerOption =      availableSpace / static_cast<int>(menuTab.size());
+        int extraPixelOnOptions = availableSpace % static_cast<int>(menuTab.size());
+
+        // each tab gains an equal amount of horizontal space
+        // if space is not cleanly divisible by tab count, the earlier tabs gain one extra pixel each until we reach the requested space
+        int xLeft =  (     i     * pixelPerOption ) + offsetLeft + std::min( i,     extraPixelOnOptions );
+        int xRight = ( ( i + 1 ) * pixelPerOption ) + offsetLeft + std::min( i + 1, extraPixelOnOptions );
+        int yTextTop = 6;
+        int yCurrentTabBoxTop = 21;
+        int yCurrentTabBoxBottom = 24;
+
+        ui3dsDrawStringWithNoWrapping(xLeft, yTextTop, xRight, yCurrentTabBoxTop, color, HALIGN_CENTER, menuTab[i].Title);
+
+        if (i == currentMenuTab) {
+            ui3dsDrawRect(xLeft, yCurrentTabBoxTop, xRight, yCurrentTabBoxBottom, 0xFFFFFF);
+        }
     }
 
     // Shadows

--- a/source/3dsmenu.cpp
+++ b/source/3dsmenu.cpp
@@ -470,7 +470,7 @@ static u32 thisKeysHeld = 0;
 // Displays the menu and allows the user to select from
 // a list of choices.
 //
-int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab, void (*itemChangedCallback)(int ID, int value))
+int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab)
 {
     int framesDKeyHeld = 0;
     int returnResult = -1;
@@ -535,7 +535,7 @@ int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuT
                     if (currentTab->MenuItems[currentTab->SelectedItemIndex].Value <
                         currentTab->MenuItems[currentTab->SelectedItemIndex].GaugeMaxValue)
                     {
-                        currentTab->MenuItems[currentTab->SelectedItemIndex].Value ++ ;
+                        currentTab->MenuItems[currentTab->SelectedItemIndex].SetValue(currentTab->MenuItems[currentTab->SelectedItemIndex].Value + 1);
                     }
                     menu3dsDrawEverything(dialogTab, isDialog, currentMenuTab, menuTab);
                 }
@@ -556,7 +556,7 @@ int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuT
                     if (currentTab->MenuItems[currentTab->SelectedItemIndex].Value >
                         currentTab->MenuItems[currentTab->SelectedItemIndex].GaugeMinValue)
                     {
-                        currentTab->MenuItems[currentTab->SelectedItemIndex].Value -- ;
+                        currentTab->MenuItems[currentTab->SelectedItemIndex].SetValue(currentTab->MenuItems[currentTab->SelectedItemIndex].Value - 1);
                     }
                     menu3dsDrawEverything(dialogTab, isDialog, currentMenuTab, menuTab);
                 }
@@ -576,9 +576,9 @@ int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuT
             if (currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MENUITEM_CHECKBOX)
             {
                 if (currentTab->MenuItems[currentTab->SelectedItemIndex].Value == 0)
-                    currentTab->MenuItems[currentTab->SelectedItemIndex].Value = 1;
+                    currentTab->MenuItems[currentTab->SelectedItemIndex].SetValue(1);
                 else
-                    currentTab->MenuItems[currentTab->SelectedItemIndex].Value = 0;
+                    currentTab->MenuItems[currentTab->SelectedItemIndex].SetValue(0);
                 menu3dsDrawEverything(dialogTab, isDialog, currentMenuTab, menuTab);
             }
             if (currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MENUITEM_PICKER)
@@ -592,10 +592,7 @@ int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuT
                     );
                 if (resultValue != -1)
                 {
-                    if (itemChangedCallback)
-                        itemChangedCallback(currentTab->MenuItems[currentTab->SelectedItemIndex].ID, resultValue);
-                    
-                    currentTab->MenuItems[currentTab->SelectedItemIndex].Value = resultValue;
+                    currentTab->MenuItems[currentTab->SelectedItemIndex].SetValue(resultValue);
                 }
                 menu3dsDrawEverything(dialogTab, isDialog, currentMenuTab, menuTab);
                 menu3dsHideDialog(dialogTab, isDialog, currentMenuTab, menuTab);
@@ -744,7 +741,7 @@ void menu3dsSetValueByID(std::vector<SMenuTab>& menuTab, int tabIndex, int ID, i
     {
         if (currentTab->MenuItems[i].ID == ID)
         {
-            currentTab->MenuItems[i].Value = value;
+            currentTab->MenuItems[i].SetValue(value);
             break;
         }
     }
@@ -765,7 +762,7 @@ int menu3dsGetValueByID(std::vector<SMenuTab>& menuTab, int tabIndex, int ID)
     return -1;
 }
 
-int menu3dsShowMenu(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab, void (*itemChangedCallback)(int ID, int value), bool animateMenu)
+int menu3dsShowMenu(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab, bool animateMenu)
 {
     isDialog = false;
 
@@ -779,7 +776,7 @@ int menu3dsShowMenu(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, st
         }
     }
 
-    return menu3dsMenuSelectItem(dialogTab, isDialog, currentMenuTab, menuTab, itemChangedCallback);
+    return menu3dsMenuSelectItem(dialogTab, isDialog, currentMenuTab, menuTab);
 
 }
 
@@ -839,7 +836,7 @@ int menu3dsShowDialog(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, 
     //
     if (currentTab->ItemCount > 0)
     {
-        int result = menu3dsMenuSelectItem(dialogTab, isDialog, currentMenuTab, menuTab, NULL);
+        int result = menu3dsMenuSelectItem(dialogTab, isDialog, currentMenuTab, menuTab);
 
         return result;
     }

--- a/source/3dsmenu.cpp
+++ b/source/3dsmenu.cpp
@@ -630,7 +630,7 @@ int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuT
                 ) &&
                 moveCursorTimes < currentTab->MenuItems.size());
 
-            currentTab->MakeSureSelectionIsOnScreen(maxItems);
+            currentTab->MakeSureSelectionIsOnScreen(maxItems, isDialog ? 1 : 2);
             menu3dsDrawEverything(dialogTab, isDialog, currentMenuTab, menuTab);
 
         }
@@ -663,7 +663,7 @@ int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuT
                 ) &&
                 moveCursorTimes < currentTab->MenuItems.size());
 
-            currentTab->MakeSureSelectionIsOnScreen(maxItems);
+            currentTab->MakeSureSelectionIsOnScreen(maxItems, isDialog ? 1 : 2);
             menu3dsDrawEverything(dialogTab, isDialog, currentMenuTab, menuTab);
         }
 
@@ -691,7 +691,7 @@ void menu3dsAddTab(std::vector<SMenuTab>& menuTab, char *title, const std::vecto
         if (menuItems[i].IsHighlightable())
         {
             currentTab->SelectedItemIndex = i;
-            currentTab->MakeSureSelectionIsOnScreen(MENU_HEIGHT);
+            currentTab->MakeSureSelectionIsOnScreen(MENU_HEIGHT, 2);
             break;
         }
     }
@@ -706,7 +706,7 @@ void menu3dsSetSelectedItemByIndex(SMenuTab& tab, int index)
         if (!tab.SubTitle.empty()) {
             maxItems--;
         }
-        tab.MakeSureSelectionIsOnScreen(maxItems);
+        tab.MakeSureSelectionIsOnScreen(maxItems, 2);
     }
 }
 
@@ -758,7 +758,7 @@ int menu3dsShowDialog(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, 
             menuItems[i].Value == selectedID)
         {
             currentTab->SelectedItemIndex = i;
-            currentTab->MakeSureSelectionIsOnScreen(DIALOG_HEIGHT);
+            currentTab->MakeSureSelectionIsOnScreen(DIALOG_HEIGHT, 1);
             break;
         }
     }

--- a/source/3dsmenu.cpp
+++ b/source/3dsmenu.cpp
@@ -118,23 +118,23 @@ void menu3dsDrawItems(
             ui3dsDrawRect(0, y, 320, y + 14, selectedItemBackColor);
         }
         
-        if (currentTab->MenuItems[i].Type == MENUITEM_HEADER1)
+        if (currentTab->MenuItems[i].Type == MenuItemType::Header1)
         {
             color = headerItemTextColor;
             ui3dsDrawStringWithNoWrapping(horizontalPadding, y, 320 - horizontalPadding, y + fontHeight, color, HALIGN_LEFT, currentTab->MenuItems[i].Text.c_str());
             ui3dsDrawRect(horizontalPadding, y + fontHeight - 1, 320 - horizontalPadding, y + fontHeight, color);
         }
-        else if (currentTab->MenuItems[i].Type == MENUITEM_HEADER2)
+        else if (currentTab->MenuItems[i].Type == MenuItemType::Header2)
         {
             color = headerItemTextColor;
             ui3dsDrawStringWithNoWrapping(horizontalPadding, y, 320 - horizontalPadding, y + fontHeight, color, HALIGN_LEFT, currentTab->MenuItems[i].Text.c_str());
         }
-        else if (currentTab->MenuItems[i].Type == MENUITEM_DISABLED)
+        else if (currentTab->MenuItems[i].Type == MenuItemType::Disabled)
         {
             color = disabledItemTextColor;
             ui3dsDrawStringWithNoWrapping(horizontalPadding, y, 320 - horizontalPadding, y + fontHeight, color, HALIGN_LEFT, currentTab->MenuItems[i].Text.c_str());
         }
-        else if (currentTab->MenuItems[i].Type == MENUITEM_ACTION)
+        else if (currentTab->MenuItems[i].Type == MenuItemType::Action)
         {
             color = normalItemTextColor;
             if (currentTab->SelectedItemIndex == i)
@@ -149,7 +149,7 @@ void menu3dsDrawItems(
                 ui3dsDrawStringWithNoWrapping(horizontalPadding, y, 320 - horizontalPadding, y + fontHeight, color, HALIGN_RIGHT, currentTab->MenuItems[i].Description.c_str());
             }
         }
-        else if (currentTab->MenuItems[i].Type == MENUITEM_CHECKBOX)
+        else if (currentTab->MenuItems[i].Type == MenuItemType::Checkbox)
         {
             if (currentTab->MenuItems[i].Value == 0)
             {
@@ -170,7 +170,7 @@ void menu3dsDrawItems(
                 ui3dsDrawStringWithNoWrapping(280, y, 320 - horizontalPadding, y + fontHeight, color, HALIGN_RIGHT, "\xfd");
             }
         }
-        else if (currentTab->MenuItems[i].Type == MENUITEM_GAUGE)
+        else if (currentTab->MenuItems[i].Type == MenuItemType::Gauge)
         {
             color = normalItemTextColor;
             if (currentTab->SelectedItemIndex == i)
@@ -188,7 +188,7 @@ void menu3dsDrawItems(
             gauge[max] = 0;
             ui3dsDrawStringWithNoWrapping(245, y, 320 - horizontalPadding, y + fontHeight, color, HALIGN_RIGHT, gauge);
         }
-        else if (currentTab->MenuItems[i].Type == MENUITEM_PICKER)
+        else if (currentTab->MenuItems[i].Type == MenuItemType::Picker)
         {
             color = normalItemTextColor;
             if (currentTab->SelectedItemIndex == i)
@@ -530,7 +530,7 @@ int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuT
             if (!isDialog)
             {
                 if (keysDown & KEY_RIGHT &&
-                    currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MENUITEM_GAUGE)
+                    currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MenuItemType::Gauge)
                 {
                     if (currentTab->MenuItems[currentTab->SelectedItemIndex].Value <
                         currentTab->MenuItems[currentTab->SelectedItemIndex].GaugeMaxValue)
@@ -550,7 +550,7 @@ int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuT
             if (!isDialog)
             {
                 if (keysDown & KEY_LEFT &&
-                    currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MENUITEM_GAUGE)
+                    currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MenuItemType::Gauge)
                 {
                     // Gauge adjustment
                     if (currentTab->MenuItems[currentTab->SelectedItemIndex].Value >
@@ -568,12 +568,12 @@ int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuT
         }
         if (keysDown & KEY_START || keysDown & KEY_A)
         {
-            if (currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MENUITEM_ACTION)
+            if (currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MenuItemType::Action)
             {
                 returnResult = currentTab->MenuItems[currentTab->SelectedItemIndex].ID;
                 break;
             }
-            if (currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MENUITEM_CHECKBOX)
+            if (currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MenuItemType::Checkbox)
             {
                 if (currentTab->MenuItems[currentTab->SelectedItemIndex].Value == 0)
                     currentTab->MenuItems[currentTab->SelectedItemIndex].SetValue(1);
@@ -581,7 +581,7 @@ int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuT
                     currentTab->MenuItems[currentTab->SelectedItemIndex].SetValue(0);
                 menu3dsDrawEverything(dialogTab, isDialog, currentMenuTab, menuTab);
             }
-            if (currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MENUITEM_PICKER)
+            if (currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MenuItemType::Picker)
             {
                 snprintf(menuTextBuffer, 511, "%s", currentTab->MenuItems[currentTab->SelectedItemIndex].Text.c_str());
                 int resultValue = menu3dsShowDialog(dialogTab, isDialog, currentMenuTab, menuTab, menuTextBuffer,
@@ -623,9 +623,9 @@ int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuT
                 moveCursorTimes++;
             }
             while (
-                (currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MENUITEM_DISABLED ||
-                currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MENUITEM_HEADER1 ||
-                currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MENUITEM_HEADER2
+                (currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MenuItemType::Disabled ||
+                currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MenuItemType::Header1 ||
+                currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MenuItemType::Header2
                 ) &&
                 moveCursorTimes < currentTab->ItemCount);
 
@@ -660,9 +660,9 @@ int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuT
                 moveCursorTimes++;
             }
             while (
-                (currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MENUITEM_DISABLED ||
-                currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MENUITEM_HEADER1 ||
-                currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MENUITEM_HEADER2
+                (currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MenuItemType::Disabled ||
+                currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MenuItemType::Header1 ||
+                currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MenuItemType::Header2
                 ) &&
                 moveCursorTimes < currentTab->ItemCount);
 

--- a/source/3dsmenu.cpp
+++ b/source/3dsmenu.cpp
@@ -202,7 +202,7 @@ void menu3dsDrawItems(
                 for (int j = 0; j < currentTab->MenuItems[i].PickerItems.size(); j++)
                 {
                     std::vector<SMenuItem>& pickerItems = currentTab->MenuItems[i].PickerItems;
-                    if (pickerItems[j].ID == currentTab->MenuItems[i].Value)
+                    if (pickerItems[j].Value == currentTab->MenuItems[i].Value)
                     {
                         selectedIndex = j;
                     }
@@ -570,7 +570,7 @@ int menu3dsMenuSelectItem(SMenuTab& dialogTab, bool& isDialog, int& currentMenuT
         {
             if (currentTab->MenuItems[currentTab->SelectedItemIndex].Type == MenuItemType::Action)
             {
-                returnResult = currentTab->MenuItems[currentTab->SelectedItemIndex].ID;
+                returnResult = currentTab->MenuItems[currentTab->SelectedItemIndex].Value;
                 currentTab->MenuItems[currentTab->SelectedItemIndex].SetValue(1);
                 break;
             }
@@ -771,7 +771,7 @@ int menu3dsShowDialog(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, 
     for (int i = 0; i < currentTab->MenuItems.size(); i++)
     {
         if ((selectedID == -1 && menuItems[i].IsHighlightable()) || 
-            menuItems[i].ID == selectedID)
+            menuItems[i].Value == selectedID)
         {
             currentTab->SelectedItemIndex = i;
             if (currentTab->SelectedItemIndex >= currentTab->FirstItemIndex + DIALOG_HEIGHT)

--- a/source/3dsmenu.cpp
+++ b/source/3dsmenu.cpp
@@ -695,7 +695,7 @@ void menu3dsAddTab(std::vector<SMenuTab>& menuTab, char *title, const std::vecto
     currentTab->SelectedItemIndex = 0;
     for (int i = 0; i < currentTab->MenuItems.size(); i++)
     {
-        if (menuItems[i].ID > -1)
+        if (menuItems[i].IsHighlightable())
         {
             currentTab->SelectedItemIndex = i;
             if (currentTab->SelectedItemIndex >= currentTab->FirstItemIndex + MENU_HEIGHT)
@@ -769,7 +769,7 @@ int menu3dsShowDialog(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, 
 
     for (int i = 0; i < currentTab->MenuItems.size(); i++)
     {
-        if ((selectedID == -1 && menuItems[i].ID > -1) || 
+        if ((selectedID == -1 && menuItems[i].IsHighlightable()) || 
             menuItems[i].ID == selectedID)
         {
             currentTab->SelectedItemIndex = i;

--- a/source/3dsmenu.h
+++ b/source/3dsmenu.h
@@ -82,6 +82,14 @@ public:
         size_t offs = title.find_first_not_of(' ');
         Title.assign(offs != title.npos ? title.substr(offs) : title);
     }
+
+    void MakeSureSelectionIsOnScreen(int maxItems) {
+        if (SelectedItemIndex < FirstItemIndex) {
+            FirstItemIndex = SelectedItemIndex;
+        } else if (SelectedItemIndex >= FirstItemIndex + maxItems) {
+            FirstItemIndex = SelectedItemIndex - maxItems + 1;
+        }
+    }
 };
 
 

--- a/source/3dsmenu.h
+++ b/source/3dsmenu.h
@@ -19,8 +19,6 @@ class SMenuItem {
 public:
     MenuItemType Type;
 
-    int     ID;                 
-    
     std::string Text;
 
     std::string Description;
@@ -50,10 +48,10 @@ protected:
 public:
     SMenuItem(
         std::function<void(int)> callback,
-        MenuItemType type, int id, const std::string& text, const std::string& description, int value = 0,
+        MenuItemType type, const std::string& text, const std::string& description, int value = 0,
         int min = 0, int max = 0,
         const std::string& pickerDesc = std::string(), const std::vector<SMenuItem>& pickerItems = std::vector<SMenuItem>(), int pickerColor = 0
-    ) : ValueChangedCallback(callback), Type(type), ID(id), Text(text), Description(description), Value(value),
+    ) : ValueChangedCallback(callback), Type(type), Text(text), Description(description), Value(value),
         GaugeMinValue(min), GaugeMaxValue(max),
         PickerDescription(pickerDesc), PickerItems(pickerItems), PickerBackColor(pickerColor) {}
 

--- a/source/3dsmenu.h
+++ b/source/3dsmenu.h
@@ -86,9 +86,7 @@ public:
 void menu3dsSetTransferGameScreen(bool transfer);
 
 void menu3dsAddTab(std::vector<SMenuTab>& menuTab, char *title, const std::vector<SMenuItem>& menuItems);
-void menu3dsSetSelectedItemIndexByID(int& currentMenuTab, std::vector<SMenuTab>& menuTab, int tabIndex, int ID);
-void menu3dsSetValueByID(std::vector<SMenuTab>& menuTab, int tabIndex, int ID, int value);
-int menu3dsGetValueByID(std::vector<SMenuTab>& menuTab, int tabIndex, int ID);
+void menu3dsSetSelectedItemByIndex(SMenuTab& tab, int index);
 
 void menu3dsDrawBlackScreen(float opacity = 1.0f);
 

--- a/source/3dsmenu.h
+++ b/source/3dsmenu.h
@@ -52,11 +52,17 @@ class SMenuTab {
 public:
     SMenuItem   *MenuItems;
     std::string SubTitle;
-    char        *Title;
-    char        *DialogText;
+    std::string Title;
+    std::string DialogText;
     int         ItemCount;
     int         FirstItemIndex;
     int         SelectedItemIndex;
+
+    void SetTitle(const std::string& title) {
+        // Left trim the dialog title
+        size_t offs = title.find_first_not_of(' ');
+        Title.assign(offs != title.npos ? title.substr(offs) : title);
+    }
 };
 
 

--- a/source/3dsmenu.h
+++ b/source/3dsmenu.h
@@ -75,11 +75,11 @@ int menu3dsGetValueByID(std::vector<SMenuTab>& menuTab, int tabIndex, int ID);
 
 void menu3dsDrawBlackScreen(float opacity = 1.0f);
 
-int menu3dsShowMenu(bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab, void (*itemChangedCallback)(int ID, int value), bool animateMenu);
-void menu3dsHideMenu(bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab);
+int menu3dsShowMenu(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab, void (*itemChangedCallback)(int ID, int value), bool animateMenu);
+void menu3dsHideMenu(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab);
 
-int menu3dsShowDialog(bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab, char *title, char *dialogText, int dialogBackColor, SMenuItem *menuItems, int itemCount, int selectedID = -1);
-void menu3dsHideDialog(bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab);
+int menu3dsShowDialog(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab, char *title, char *dialogText, int dialogBackColor, SMenuItem *menuItems, int itemCount, int selectedID = -1);
+void menu3dsHideDialog(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab);
 
 bool menu3dsTakeScreenshot(const char *path);
 

--- a/source/3dsmenu.h
+++ b/source/3dsmenu.h
@@ -32,6 +32,7 @@ public:
                                 // Type = Picker:
                                 //   Selected ID of Picker
 
+    // We currently abuse this value to determine if a picker should show its selected option in the menu or not.
     int     GaugeMinValue;
     int     GaugeMaxValue;      // Set MinValue < MaxValue to make the gauge visible.
 

--- a/source/3dsmenu.h
+++ b/source/3dsmenu.h
@@ -12,8 +12,8 @@
 #define MENUITEM_GAUGE              4
 #define MENUITEM_PICKER             5
 
-typedef struct
-{
+class SMenuItem {
+public:
     int     Type;               // -1 - Disabled
                                 // 0 - Header
                                 // 1 - Action 
@@ -23,9 +23,9 @@ typedef struct
 
     int     ID;                 
     
-    char    *Text;
+    std::string Text;
 
-    char    *Description;
+    std::string Description;
 
     int     Value;              
                                 // Type = Gauge:
@@ -42,15 +42,24 @@ typedef struct
     // All these fields are used if this is a picker.
     // (ID = 100000)
     //
-    char    *PickerDescription;
-    int     PickerItemCount;
-    void    *PickerItems;
+    std::string PickerDescription;
+    std::vector<SMenuItem> PickerItems;
     int     PickerBackColor;
-} SMenuItem;
+
+    SMenuItem(
+        int type, int id, const std::string& text, const std::string& description, int value = 0,
+        int min = 0, int max = 0,
+        const std::string& pickerDesc = std::string(), const std::vector<SMenuItem>& pickerItems = std::vector<SMenuItem>(), int pickerColor = 0
+    ) : Type(type), ID(id), Text(text), Description(description), Value(value),
+        GaugeMinValue(min), GaugeMaxValue(max),
+        PickerDescription(pickerDesc), PickerItems(pickerItems), PickerBackColor(pickerColor) {}
+
+
+};
 
 class SMenuTab {
 public:
-    SMenuItem   *MenuItems;
+    std::vector<SMenuItem> MenuItems;
     std::string SubTitle;
     std::string Title;
     std::string DialogText;
@@ -68,7 +77,7 @@ public:
 
 void menu3dsSetTransferGameScreen(bool transfer);
 
-void menu3dsAddTab(std::vector<SMenuTab>& menuTab, char *title, SMenuItem *menuItems, int itemCount);
+void menu3dsAddTab(std::vector<SMenuTab>& menuTab, char *title, const std::vector<SMenuItem>& menuItems);
 void menu3dsSetSelectedItemIndexByID(int& currentMenuTab, std::vector<SMenuTab>& menuTab, int tabIndex, int ID);
 void menu3dsSetValueByID(std::vector<SMenuTab>& menuTab, int tabIndex, int ID, int value);
 int menu3dsGetValueByID(std::vector<SMenuTab>& menuTab, int tabIndex, int ID);
@@ -78,7 +87,7 @@ void menu3dsDrawBlackScreen(float opacity = 1.0f);
 int menu3dsShowMenu(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab, void (*itemChangedCallback)(int ID, int value), bool animateMenu);
 void menu3dsHideMenu(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab);
 
-int menu3dsShowDialog(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab, char *title, char *dialogText, int dialogBackColor, SMenuItem *menuItems, int itemCount, int selectedID = -1);
+int menu3dsShowDialog(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab, const std::string& title, const std::string& dialogText, int dialogBackColor, const std::vector<SMenuItem>& menuItems, int selectedID = -1);
 void menu3dsHideDialog(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab);
 
 bool menu3dsTakeScreenshot(const char *path);

--- a/source/3dsmenu.h
+++ b/source/3dsmenu.h
@@ -83,11 +83,18 @@ public:
         Title.assign(offs != title.npos ? title.substr(offs) : title);
     }
 
-    void MakeSureSelectionIsOnScreen(int maxItems) {
-        if (SelectedItemIndex < FirstItemIndex) {
-            FirstItemIndex = SelectedItemIndex;
-        } else if (SelectedItemIndex >= FirstItemIndex + maxItems) {
-            FirstItemIndex = SelectedItemIndex - maxItems + 1;
+    void MakeSureSelectionIsOnScreen(int maxItems, int spacing) {
+        int offs = spacing;
+        // the visible item count must fit at least two spacings and one item in the middle for sensible scrolling logic
+        if (offs * 2 + 1 >= maxItems) {
+            offs = ( maxItems - 1 ) / 2;
+        }
+        if (SelectedItemIndex < FirstItemIndex + offs) {
+            FirstItemIndex = SelectedItemIndex < offs ? 0 : ( SelectedItemIndex - offs );
+        } else if (SelectedItemIndex >= FirstItemIndex + maxItems - offs) {
+            int top = SelectedItemIndex - maxItems + 1;
+            int itemsBelow = static_cast<int>(MenuItems.size()) - SelectedItemIndex - 1;
+            FirstItemIndex = itemsBelow < offs ? ( top + itemsBelow ) : ( top + offs );
         }
     }
 };

--- a/source/3dsmenu.h
+++ b/source/3dsmenu.h
@@ -1,6 +1,7 @@
-
 #ifndef _3DSMENU_H_
 #define _3DSMENU_H_
+
+#include <vector>
 
 #define MENUITEM_DISABLED           -1
 #define MENUITEM_HEADER1            0
@@ -46,26 +47,33 @@ typedef struct
     int     PickerBackColor;
 } SMenuItem;
 
-
+typedef struct
+{
+    SMenuItem   *MenuItems;
+    char        SubTitle[256];
+    char        *Title;
+    char        *DialogText;
+    int         ItemCount;
+    int         FirstItemIndex;
+    int         SelectedItemIndex;
+} SMenuTab;
 
 
 void menu3dsSetTransferGameScreen(bool transfer);
 
-void menu3dsSetTabSubTitle(int tabIndex, char *subtitle);
-void menu3dsAddTab(char *title, SMenuItem *menuItems, int itemCount);
-void menu3dsClearMenuTabs();
-void menu3dsSetCurrentMenuTab(int tabIndex);
-void menu3dsSetSelectedItemIndexByID(int tabIndex, int ID);
-void menu3dsSetValueByID(int tabIndex, int ID, int value);
-int menu3dsGetValueByID(int tabIndex, int ID);
+void menu3dsSetTabSubTitle(std::vector<SMenuTab>& menuTab, int tabIndex, char *subtitle);
+void menu3dsAddTab(std::vector<SMenuTab>& menuTab, char *title, SMenuItem *menuItems, int itemCount);
+void menu3dsSetSelectedItemIndexByID(int& currentMenuTab, std::vector<SMenuTab>& menuTab, int tabIndex, int ID);
+void menu3dsSetValueByID(std::vector<SMenuTab>& menuTab, int tabIndex, int ID, int value);
+int menu3dsGetValueByID(std::vector<SMenuTab>& menuTab, int tabIndex, int ID);
 
 void menu3dsDrawBlackScreen(float opacity = 1.0f);
 
-int menu3dsShowMenu(void (*itemChangedCallback)(int ID, int value), bool animateMenu);
-void menu3dsHideMenu();
+int menu3dsShowMenu(bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab, void (*itemChangedCallback)(int ID, int value), bool animateMenu);
+void menu3dsHideMenu(bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab);
 
-int menu3dsShowDialog(char *title, char *dialogText, int dialogBackColor, SMenuItem *menuItems, int itemCount, int selectedID = -1);
-void menu3dsHideDialog();
+int menu3dsShowDialog(bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab, char *title, char *dialogText, int dialogBackColor, SMenuItem *menuItems, int itemCount, int selectedID = -1);
+void menu3dsHideDialog(bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab);
 
 bool menu3dsTakeScreenshot(const char *path);
 

--- a/source/3dsmenu.h
+++ b/source/3dsmenu.h
@@ -1,6 +1,7 @@
 #ifndef _3DSMENU_H_
 #define _3DSMENU_H_
 
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -46,15 +47,25 @@ public:
     std::vector<SMenuItem> PickerItems;
     int     PickerBackColor;
 
+protected:
+    std::function<void(int)> ValueChangedCallback;
+
+public:
     SMenuItem(
+        std::function<void(int)> callback,
         int type, int id, const std::string& text, const std::string& description, int value = 0,
         int min = 0, int max = 0,
         const std::string& pickerDesc = std::string(), const std::vector<SMenuItem>& pickerItems = std::vector<SMenuItem>(), int pickerColor = 0
-    ) : Type(type), ID(id), Text(text), Description(description), Value(value),
+    ) : ValueChangedCallback(callback), Type(type), ID(id), Text(text), Description(description), Value(value),
         GaugeMinValue(min), GaugeMaxValue(max),
         PickerDescription(pickerDesc), PickerItems(pickerItems), PickerBackColor(pickerColor) {}
 
-
+    void SetValue(int value) {
+        this->Value = value;
+        if (this->ValueChangedCallback) {
+            this->ValueChangedCallback(value);
+        }
+    }
 };
 
 class SMenuTab {
@@ -84,7 +95,7 @@ int menu3dsGetValueByID(std::vector<SMenuTab>& menuTab, int tabIndex, int ID);
 
 void menu3dsDrawBlackScreen(float opacity = 1.0f);
 
-int menu3dsShowMenu(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab, void (*itemChangedCallback)(int ID, int value), bool animateMenu);
+int menu3dsShowMenu(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab, bool animateMenu);
 void menu3dsHideMenu(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab);
 
 int menu3dsShowDialog(SMenuTab& dialogTab, bool& isDialog, int& currentMenuTab, std::vector<SMenuTab>& menuTab, const std::string& title, const std::string& dialogText, int dialogBackColor, const std::vector<SMenuItem>& menuItems, int selectedID = -1);

--- a/source/3dsmenu.h
+++ b/source/3dsmenu.h
@@ -71,7 +71,6 @@ public:
     std::string SubTitle;
     std::string Title;
     std::string DialogText;
-    int         ItemCount;
     int         FirstItemIndex;
     int         SelectedItemIndex;
 

--- a/source/3dsmenu.h
+++ b/source/3dsmenu.h
@@ -1,6 +1,7 @@
 #ifndef _3DSMENU_H_
 #define _3DSMENU_H_
 
+#include <string>
 #include <vector>
 
 #define MENUITEM_DISABLED           -1
@@ -47,21 +48,20 @@ typedef struct
     int     PickerBackColor;
 } SMenuItem;
 
-typedef struct
-{
+class SMenuTab {
+public:
     SMenuItem   *MenuItems;
-    char        SubTitle[256];
+    std::string SubTitle;
     char        *Title;
     char        *DialogText;
     int         ItemCount;
     int         FirstItemIndex;
     int         SelectedItemIndex;
-} SMenuTab;
+};
 
 
 void menu3dsSetTransferGameScreen(bool transfer);
 
-void menu3dsSetTabSubTitle(std::vector<SMenuTab>& menuTab, int tabIndex, char *subtitle);
 void menu3dsAddTab(std::vector<SMenuTab>& menuTab, char *title, SMenuItem *menuItems, int itemCount);
 void menu3dsSetSelectedItemIndexByID(int& currentMenuTab, std::vector<SMenuTab>& menuTab, int tabIndex, int ID);
 void menu3dsSetValueByID(std::vector<SMenuTab>& menuTab, int tabIndex, int ID, int value);

--- a/source/3dsmenu.h
+++ b/source/3dsmenu.h
@@ -5,22 +5,19 @@
 #include <string>
 #include <vector>
 
-#define MENUITEM_DISABLED           -1
-#define MENUITEM_HEADER1            0
-#define MENUITEM_HEADER2            1
-#define MENUITEM_ACTION             2
-#define MENUITEM_CHECKBOX           3
-#define MENUITEM_GAUGE              4
-#define MENUITEM_PICKER             5
+enum class MenuItemType {
+    Disabled,
+    Header1,
+    Header2,
+    Action,
+    Checkbox,
+    Gauge,
+    Picker,
+};
 
 class SMenuItem {
 public:
-    int     Type;               // -1 - Disabled
-                                // 0 - Header
-                                // 1 - Action 
-                                // 2 - Checkbox
-                                // 3 - Gauge
-                                // 4 - Picker
+    MenuItemType Type;
 
     int     ID;                 
     
@@ -53,7 +50,7 @@ protected:
 public:
     SMenuItem(
         std::function<void(int)> callback,
-        int type, int id, const std::string& text, const std::string& description, int value = 0,
+        MenuItemType type, int id, const std::string& text, const std::string& description, int value = 0,
         int min = 0, int max = 0,
         const std::string& pickerDesc = std::string(), const std::vector<SMenuItem>& pickerItems = std::vector<SMenuItem>(), int pickerColor = 0
     ) : ValueChangedCallback(callback), Type(type), ID(id), Text(text), Description(description), Value(value),

--- a/source/3dsmenu.h
+++ b/source/3dsmenu.h
@@ -63,6 +63,10 @@ public:
             this->ValueChangedCallback(value);
         }
     }
+
+    bool IsHighlightable() const {
+        return !( Type == MenuItemType::Disabled || Type == MenuItemType::Header1 || Type == MenuItemType::Header2 );
+    }
 };
 
 class SMenuTab {

--- a/source/3dssettings.h
+++ b/source/3dssettings.h
@@ -50,4 +50,5 @@ typedef struct
                                             //   0 - Disabled
                                             //   1 - Enabled
 
+    bool    Changed = false;                // Stores whether the configuration has been changed and should be written.
 } S9xSettings3DS;


### PR DESCRIPTION
This originally started as an idea to extract the menu into a library, since it's a pretty nice menu, but I didn't quite get that far. However, I figured I'd submit this as-is for now as I'm not sure how much time I'll have to work on it in the near future.

This refactors the menu to be less reliant on global variables and statically preallocated items. In other words, this allows you to build the menu at runtime and have several different menu instances around at once. Menu actions are now (mostly) executed via callbacks, too, so the code that displays the menu doesn't have to know what the menu actually does. It's not quite as clean as I wish it were, admittedly, but I'd say it's better than before.

In terms of functionality, there should be no user-visible difference in how the menu works, except for fixing #6 by not limiting the per-directory file count.

I haven't gotten around to test this on actual hardware yet, but it seems to work nicely in Citra.

Suggestions are welcome.