### PR TITLE
Remappable SNES buttons.

### DIFF
--- a/source/3dsconfig.cpp
+++ b/source/3dsconfig.cpp
@@ -40,7 +40,7 @@ void config3dsCloseFile()
 //----------------------------------------------------------------------
 // Load / Save an int32 value specific to game.
 //----------------------------------------------------------------------
-void config3dsReadWriteInt32(char *format, int *value, int minValue, int maxValue)
+void config3dsReadWriteInt32(const char *format, int *value, int minValue, int maxValue)
 {
     if (!fp)
         return;
@@ -84,7 +84,7 @@ void config3dsReadWriteInt32(char *format, int *value, int minValue, int maxValu
 //----------------------------------------------------------------------
 // Load / Save a string specific to game.
 //----------------------------------------------------------------------
-void config3dsReadWriteString(char *writeFormat, char *readFormat, char *value)
+void config3dsReadWriteString(const char *writeFormat, char *readFormat, char *value)
 {
     if (!fp)
         return;

--- a/source/3dsconfig.h
+++ b/source/3dsconfig.h
@@ -23,13 +23,13 @@ void    config3dsCloseFile();
 //----------------------------------------------------------------------
 // Load / Save an int32 value specific to game.
 //----------------------------------------------------------------------
-void    config3dsReadWriteInt32(char *format, int *value, int minValue = 0, int maxValue = 0xffff);
+void    config3dsReadWriteInt32(const char *format, int *value, int minValue = 0, int maxValue = 0xffff);
 
 
 //----------------------------------------------------------------------
 // Load / Save a string specific to game.
 //----------------------------------------------------------------------
-void    config3dsReadWriteString(char *writeFormat, char *readFormat, char *value);
+void    config3dsReadWriteString(const char *writeFormat, char *readFormat, char *value);
 
 #endif
 

--- a/source/3dsimpl.cpp
+++ b/source/3dsimpl.cpp
@@ -881,21 +881,31 @@ uint32 S9xReadJoypad (int which1_0_to_4)
     if (which1_0_to_4 != 0)
         return 0;
 
-	uint32 s9xKeysHeld = input3dsGetCurrentKeysHeld();
-    uint32 snesJoyPad = 0;
+    // TODO: ideally we initialize this in a way that ensures snes9xMasks[SnesButtons::A] == SNES_A_MASK,
+    // but how do we do that at compile time?
+    static std::array<uint32, static_cast<size_t>(SnesButtons::Count)> snes9xMasks = {
+        SNES_A_MASK,
+        SNES_B_MASK,
+        SNES_Y_MASK,
+        SNES_X_MASK,
+        SNES_TL_MASK,
+        SNES_TR_MASK,
+        SNES_UP_MASK,
+        SNES_DOWN_MASK,
+        SNES_LEFT_MASK,
+        SNES_RIGHT_MASK,
+        SNES_START_MASK,
+        SNES_SELECT_MASK,
+    };
 
-    if (s9xKeysHeld & KEY_UP) snesJoyPad |= SNES_UP_MASK;
-    if (s9xKeysHeld & KEY_DOWN) snesJoyPad |= SNES_DOWN_MASK;
-    if (s9xKeysHeld & KEY_LEFT) snesJoyPad |= SNES_LEFT_MASK;
-    if (s9xKeysHeld & KEY_RIGHT) snesJoyPad |= SNES_RIGHT_MASK;
-    if (s9xKeysHeld & KEY_L) snesJoyPad |= SNES_TL_MASK;
-    if (s9xKeysHeld & KEY_R) snesJoyPad |= SNES_TR_MASK;
-    if (s9xKeysHeld & KEY_SELECT) snesJoyPad |= SNES_SELECT_MASK;
-    if (s9xKeysHeld & KEY_START) snesJoyPad |= SNES_START_MASK;
-    if (s9xKeysHeld & KEY_A) snesJoyPad |= SNES_A_MASK;
-    if (s9xKeysHeld & KEY_B) snesJoyPad |= SNES_B_MASK;
-    if (s9xKeysHeld & KEY_X) snesJoyPad |= SNES_X_MASK;
-    if (s9xKeysHeld & KEY_Y) snesJoyPad |= SNES_Y_MASK;
+    uint32 keysHeld3ds = input3dsGetCurrentKeysHeld();
+
+    uint32 snesJoyPad = 0;
+    for (size_t i = 0; i < snes9xMasks.size(); ++i) {
+        if (settings3DS.ButtonMappingsSnes[i].IsHeld(keysHeld3ds)) {
+            snesJoyPad |= snes9xMasks[i];
+        }
+    }
 
     // Handle turbo buttons.
     //

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -60,6 +60,24 @@ char romFileName[_MAX_PATH];
 char romFileNameLastSelected[_MAX_PATH];
 
 
+void LoadDefaultSettings() {
+    settings3DS.PaletteFix = 0;
+    settings3DS.SRAMSaveInterval = 0;
+    settings3DS.ForceSRAMWriteOnPause = 0;
+
+    settings3DS.ButtonMappingsSnes[static_cast<size_t>(SnesButtons::A     )].SetSingleMapping(KEY_A);
+    settings3DS.ButtonMappingsSnes[static_cast<size_t>(SnesButtons::B     )].SetSingleMapping(KEY_B);
+    settings3DS.ButtonMappingsSnes[static_cast<size_t>(SnesButtons::Y     )].SetSingleMapping(KEY_Y);
+    settings3DS.ButtonMappingsSnes[static_cast<size_t>(SnesButtons::X     )].SetSingleMapping(KEY_X);
+    settings3DS.ButtonMappingsSnes[static_cast<size_t>(SnesButtons::L     )].SetSingleMapping(KEY_L);
+    settings3DS.ButtonMappingsSnes[static_cast<size_t>(SnesButtons::R     )].SetSingleMapping(KEY_R);
+    settings3DS.ButtonMappingsSnes[static_cast<size_t>(SnesButtons::Up    )].SetDoubleMapping(KEY_DUP,    KEY_CPAD_UP);
+    settings3DS.ButtonMappingsSnes[static_cast<size_t>(SnesButtons::Down  )].SetDoubleMapping(KEY_DDOWN,  KEY_CPAD_DOWN);
+    settings3DS.ButtonMappingsSnes[static_cast<size_t>(SnesButtons::Left  )].SetDoubleMapping(KEY_DLEFT,  KEY_CPAD_LEFT);
+    settings3DS.ButtonMappingsSnes[static_cast<size_t>(SnesButtons::Right )].SetDoubleMapping(KEY_DRIGHT, KEY_CPAD_RIGHT);
+    settings3DS.ButtonMappingsSnes[static_cast<size_t>(SnesButtons::Start )].SetSingleMapping(KEY_START);
+    settings3DS.ButtonMappingsSnes[static_cast<size_t>(SnesButtons::Select)].SetSingleMapping(KEY_SELECT);
+}
 
 
 //----------------------------------------------------------------------
@@ -552,26 +570,30 @@ bool settingsUpdateAllSettings(bool updateGameSettings = true)
     return settingsChanged;
 }
 
+namespace {
+    void config3dsReadWriteBitmask(const char* name, uint32* bitmask) {
+        int tmp = static_cast<int>(*bitmask);
+        config3dsReadWriteInt32(name, &tmp, std::numeric_limits<int>::min(), std::numeric_limits<int>::max());
+        *bitmask = static_cast<uint32>(tmp);
+    }
+}
 
 //----------------------------------------------------------------------
 // Read/write all possible game specific settings.
 //----------------------------------------------------------------------
 bool settingsReadWriteFullListByGame(bool writeMode)
 {
+    if (!writeMode) {
+        // set default values first.
+        LoadDefaultSettings();
+    }
+
     bool success = config3dsOpenFile(S9xGetFilename(".cfg"), writeMode);
     if (!success)
         return false;
 
     config3dsReadWriteInt32("#v1\n", NULL, 0, 0);
     config3dsReadWriteInt32("# Do not modify this file or risk losing your settings.\n", NULL, 0, 0);
-
-    // set default values first.
-    if (!writeMode)
-    {
-        settings3DS.PaletteFix = 0;
-        settings3DS.SRAMSaveInterval = 0;
-        settings3DS.ForceSRAMWriteOnPause = 0;
-    }
 
     config3dsReadWriteInt32("Frameskips=%d\n", &settings3DS.MaxFrameSkips, 0, 4);
     config3dsReadWriteInt32("Framerate=%d\n", &settings3DS.ForceFrameRate, 0, 2);
@@ -585,6 +607,14 @@ bool settingsReadWriteFullListByGame(bool writeMode)
     config3dsReadWriteInt32("PalFix=%d\n", &settings3DS.PaletteFix, 0, 3);
     config3dsReadWriteInt32("SRAMInterval=%d\n", &settings3DS.SRAMSaveInterval, 0, 4);
     config3dsReadWriteInt32("ForceSRAMWrite=%d\n", &settings3DS.ForceSRAMWriteOnPause, 0, 1);
+
+    for (size_t i = 0; i < settings3DS.ButtonMappingsSnes.size(); ++i) {
+        for (size_t j = 0; j < settings3DS.ButtonMappingsSnes[i].MappingBitmasks.size(); ++j) {
+            std::ostringstream oss;
+            oss << "ButtonMapping_" << i << "_" << j << "=%d\n";
+            config3dsReadWriteBitmask(oss.str().c_str(), &settings3DS.ButtonMappingsSnes[i].MappingBitmasks[j]);
+        }
+    }
 
     // All new options should come here!
 

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -333,6 +333,37 @@ std::vector<SMenuItem> makeOptionsForStretch() {
     return items;
 }
 
+std::vector<SMenuItem> makeOptionsForButtonMapping() {
+    std::vector<SMenuItem> items;
+    AddMenuDialogOption(items, 0,                                  "Not Mapped"s);
+    AddMenuDialogOption(items, static_cast<int>(KEY_A),            "3DS A Button"s);
+    AddMenuDialogOption(items, static_cast<int>(KEY_B),            "3DS B Button"s);
+    AddMenuDialogOption(items, static_cast<int>(KEY_Y),            "3DS Y Button"s);
+    AddMenuDialogOption(items, static_cast<int>(KEY_X),            "3DS X Button"s);
+    AddMenuDialogOption(items, static_cast<int>(KEY_L),            "3DS L Button"s);
+    AddMenuDialogOption(items, static_cast<int>(KEY_R),            "3DS R Button"s);
+    AddMenuDialogOption(items, static_cast<int>(KEY_START),        "3DS Start Button"s);
+    AddMenuDialogOption(items, static_cast<int>(KEY_SELECT),       "3DS Select Button"s);
+    AddMenuDialogOption(items, static_cast<int>(KEY_DUP),          "3DS D-Pad Up"s);
+    AddMenuDialogOption(items, static_cast<int>(KEY_DDOWN),        "3DS D-Pad Down"s);
+    AddMenuDialogOption(items, static_cast<int>(KEY_DLEFT),        "3DS D-Pad Left"s);
+    AddMenuDialogOption(items, static_cast<int>(KEY_DRIGHT),       "3DS D-Pad Right"s);
+    AddMenuDialogOption(items, static_cast<int>(KEY_CPAD_UP),      "3DS Circle Pad Up"s);
+    AddMenuDialogOption(items, static_cast<int>(KEY_CPAD_DOWN),    "3DS Circle Pad Down"s);
+    AddMenuDialogOption(items, static_cast<int>(KEY_CPAD_LEFT),    "3DS Circle Pad Left"s);
+    AddMenuDialogOption(items, static_cast<int>(KEY_CPAD_RIGHT),   "3DS Circle Pad Right"s);
+    /*
+    // doesn't work for some reason, see #37
+    AddMenuDialogOption(items, static_cast<int>(KEY_ZL),           "New 3DS ZL Button"s);
+    AddMenuDialogOption(items, static_cast<int>(KEY_ZR),           "New 3DS ZR Button"s);
+    AddMenuDialogOption(items, static_cast<int>(KEY_CSTICK_UP),    "New 3DS C-Stick Up"s);
+    AddMenuDialogOption(items, static_cast<int>(KEY_CSTICK_DOWN),  "New 3DS C-Stick Down"s);
+    AddMenuDialogOption(items, static_cast<int>(KEY_CSTICK_LEFT),  "New 3DS C-Stick Left"s);
+    AddMenuDialogOption(items, static_cast<int>(KEY_CSTICK_RIGHT), "New 3DS C-Stick Right"s);
+    */
+    return items;
+}
+
 std::vector<SMenuItem> makeOptionsForFrameskip() {
     std::vector<SMenuItem> items;
     AddMenuDialogOption(items, 0, "Disabled"s,                ""s);
@@ -420,6 +451,48 @@ std::vector<SMenuItem> makeOptionMenu() {
                     []( int val ) { CheckAndUpdate( settings3DS.ForceSRAMWriteOnPause, val, settings3DS.Changed ); });
     return items;
 };
+
+std::vector<SMenuItem> makeControlsMenu() {
+    std::vector<SMenuItem> items;
+
+    std::array<std::string, static_cast<size_t>( SnesButtons::Count )> snesButtonNames;
+    snesButtonNames[static_cast<int>( SnesButtons::A      )] = "A Button"s;
+    snesButtonNames[static_cast<int>( SnesButtons::B      )] = "B Button"s;
+    snesButtonNames[static_cast<int>( SnesButtons::Y      )] = "Y Button"s;
+    snesButtonNames[static_cast<int>( SnesButtons::X      )] = "X Button"s;
+    snesButtonNames[static_cast<int>( SnesButtons::L      )] = "L Button"s;
+    snesButtonNames[static_cast<int>( SnesButtons::R      )] = "R Button"s;
+    snesButtonNames[static_cast<int>( SnesButtons::Up     )] = "D-Pad Up"s;
+    snesButtonNames[static_cast<int>( SnesButtons::Down   )] = "D-Pad Down"s;
+    snesButtonNames[static_cast<int>( SnesButtons::Left   )] = "D-Pad Left"s;
+    snesButtonNames[static_cast<int>( SnesButtons::Right  )] = "D-Pad Right"s;
+    snesButtonNames[static_cast<int>( SnesButtons::Start  )] = "Start Button"s;
+    snesButtonNames[static_cast<int>( SnesButtons::Select )] = "Select Button"s;
+
+    AddMenuHeader1(items, "BUTTON CONFIGURATION"s);
+    for (size_t i = 0; i < settings3DS.ButtonMappingsSnes.size(); ++i) {
+        for (size_t j = 0; j < settings3DS.ButtonMappingsSnes[i].MappingBitmasks.size(); ++j) {
+            std::ostringstream optionName;
+            optionName << "SNES " << snesButtonNames[i] << " (";
+            switch (j) {
+                case 0: optionName << "Primary"; break;
+                case 1: optionName << "Secondary"; break;
+                case 2: optionName << "Tertiary"; break;
+                default: optionName << (j+1) << "th"; break;
+            }
+            optionName << ")";
+
+            AddMenuPicker( items, optionName.str(), ""s, makeOptionsForButtonMapping(), settings3DS.ButtonMappingsSnes[i].MappingBitmasks[j], DIALOGCOLOR_CYAN, true,
+                [i, j]( int val ) {
+                    uint32 v = static_cast<uint32>(val);
+                    CheckAndUpdate( settings3DS.ButtonMappingsSnes[i].MappingBitmasks[j], v, settings3DS.Changed );
+                }
+            );
+        }
+    }
+
+    return items;
+}
 
 void menuSetupCheats(std::vector<SMenuItem>& cheatMenu);
 
@@ -901,6 +974,11 @@ void setupPauseMenu(std::vector<SMenuTab>& menuTab, std::vector<DirectoryEntry>&
 
     {
         menu3dsAddTab(menuTab, "Options", makeOptionMenu());
+        menuTab.back().SubTitle.clear();
+    }
+
+    {
+        menu3dsAddTab(menuTab, "Controls", makeControlsMenu());
         menuTab.back().SubTitle.clear();
     }
 

--- a/source/3dssettings.h
+++ b/source/3dssettings.h
@@ -1,4 +1,55 @@
+#include <array>
 
+enum class SnesButtons {
+    A      =  0,
+    B      =  1,
+    Y      =  2,
+    X      =  3,
+    L      =  4,
+    R      =  5,
+    Up     =  6,
+    Down   =  7,
+    Left   =  8,
+    Right  =  9,
+    Start  = 10,
+    Select = 11,
+    Count  = 12
+};
+
+template <int Count>
+struct ButtonMapping {
+    std::array<uint32, Count> MappingBitmasks;
+
+    bool IsHeld(uint32 held3dsButtons) const {
+        for (uint32 mapping : MappingBitmasks) {
+            if (mapping != 0 && (mapping & held3dsButtons) == mapping) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    void SetSingleMapping(uint32 mapping) {
+        SetDoubleMapping(mapping, 0);
+    }
+
+    void SetDoubleMapping(uint32 mapping0, uint32 mapping1) {
+        if constexpr (Count > 0) {
+            MappingBitmasks[0] = mapping0;
+        }
+        if constexpr (Count > 1) {
+            MappingBitmasks[1] = mapping1;
+        }
+        if constexpr (Count > 2) {
+            for (size_t i = 2; i < MappingBitmasks.size(); ++i) {
+                MappingBitmasks[i] = 0;
+            }
+        }
+    }
+};
+
+typedef std::array<ButtonMapping<3>, static_cast<size_t>(SnesButtons::Count)> ButtonMappings3dsToSnes;
 
 typedef struct
 {
@@ -49,6 +100,8 @@ typedef struct
                                             // Some games (eg. Yoshi's Island) don't detect SRAM writes correctly.
                                             //   0 - Disabled
                                             //   1 - Enabled
+
+    ButtonMappings3dsToSnes ButtonMappingsSnes; // Stores which 3DS button(s) map to each SNES button.
 
     bool    Changed = false;                // Stores whether the configuration has been changed and should be written.
 } S9xSettings3DS;


### PR DESCRIPTION
This implements SNES button remapping functionality, so that any 3DS button or button combination can be mapped to any single SNES button.

Implements #42.