### PR TITLE
Add configurable hotkeys for opening the emulator menus and temporarily disabling the framelimiter.

### DIFF
--- a/source/3dsinput.cpp
+++ b/source/3dsinput.cpp
@@ -2,9 +2,12 @@
 #include <3ds.h>
 #include "3dsimpl.h"
 #include "3dsgpu.h"
+#include "3dssettings.h"
 
 static u32 currKeysHeld = 0;
 static u32 lastKeysHeld = 0;
+
+extern S9xSettings3DS settings3DS;
 
 //int adjustableValue = 0x70;
 
@@ -60,7 +63,7 @@ u32 input3dsScanInputForEmulation()
     // -----------------------------------------------
 #endif
 
-    if (keysDown & KEY_TOUCH)
+    if (keysDown & KEY_TOUCH || settings3DS.ButtonHotkeyOpenMenu.IsHeld(keysDown))
     {
         impl3dsTouchScreenPressed();
 

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -64,6 +64,7 @@ void LoadDefaultSettings() {
     settings3DS.PaletteFix = 0;
     settings3DS.SRAMSaveInterval = 0;
     settings3DS.ForceSRAMWriteOnPause = 0;
+    settings3DS.ButtonHotkeyOpenMenu.SetSingleMapping(0);
     settings3DS.ButtonHotkeyDisableFramelimit.SetSingleMapping(0);
 }
 
@@ -514,6 +515,13 @@ std::vector<SMenuItem> makeControlsMenu() {
         
     }
 
+    AddMenuPicker( items, "Open Emulator Menu", ""s, makeOptionsForButtonMapping(), settings3DS.ButtonHotkeyOpenMenu.MappingBitmasks[0], DIALOGCOLOR_CYAN, true,
+        []( int val ) {
+            uint32 v = static_cast<uint32>(val);
+            CheckAndUpdate( settings3DS.ButtonHotkeyOpenMenu.MappingBitmasks[0], v, settings3DS.Changed );
+        }
+    );
+
     AddMenuPicker( items, "Disable Framelimit", ""s, makeOptionsForButtonMapping(), settings3DS.ButtonHotkeyDisableFramelimit.MappingBitmasks[0], DIALOGCOLOR_CYAN, true,
         []( int val ) {
             uint32 v = static_cast<uint32>(val);
@@ -723,6 +731,7 @@ bool settingsReadWriteFullListByGame(bool writeMode)
     }
 
     config3dsReadWriteBitmask("ButtonMappingDisableFramelimitHold_0=%d\n", &settings3DS.ButtonHotkeyDisableFramelimit.MappingBitmasks[0]);
+    config3dsReadWriteBitmask("ButtonMappingOpenEmulatorMenu_0=%d\n", &settings3DS.ButtonHotkeyOpenMenu.MappingBitmasks[0]);
 
     // All new options should come here!
 

--- a/source/3dssettings.h
+++ b/source/3dssettings.h
@@ -1,3 +1,4 @@
+#include <array>
 
 enum class EmulatedFramerate {
     UseRomRegion = 0,
@@ -5,6 +6,39 @@ enum class EmulatedFramerate {
     ForceFps60 = 2,
     Match3DS = 3,
     Count = 4
+};
+
+template <int Count>
+struct ButtonMapping {
+    std::array<uint32, Count> MappingBitmasks;
+
+    bool IsHeld(uint32 held3dsButtons) const {
+        for (uint32 mapping : MappingBitmasks) {
+            if (mapping != 0 && (mapping & held3dsButtons) == mapping) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    void SetSingleMapping(uint32 mapping) {
+        SetDoubleMapping(mapping, 0);
+    }
+
+    void SetDoubleMapping(uint32 mapping0, uint32 mapping1) {
+        if constexpr (Count > 0) {
+            MappingBitmasks[0] = mapping0;
+        }
+        if constexpr (Count > 1) {
+            MappingBitmasks[1] = mapping1;
+        }
+        if constexpr (Count > 2) {
+            for (size_t i = 2; i < MappingBitmasks.size(); ++i) {
+                MappingBitmasks[i] = 0;
+            }
+        }
+    }
 };
 
 typedef struct

--- a/source/3dssettings.h
+++ b/source/3dssettings.h
@@ -98,6 +98,8 @@ typedef struct
     int     GlobalButtonMapping[8][4] = {{0,0,0,0}, {0,0,0,0}, {0,0,0,0}, {0,0,0,0}, {0,0,0,0}, {0,0,0,0}};  
     int     ButtonMapping[8][4] = {{0,0,0,0}, {0,0,0,0}, {0,0,0,0}, {0,0,0,0}, {0,0,0,0}, {0,0,0,0}};  
 
+    ::ButtonMapping<1> ButtonHotkeyDisableFramelimit; // Stores button that can be held to disable the frame limit.
+
     bool    Changed = false;                // Stores whether the configuration has been changed and should be written.
 
     int     UseGlobalButtonMappings = 0;    // Use global button mappings for all games

--- a/source/3dssettings.h
+++ b/source/3dssettings.h
@@ -98,6 +98,8 @@ typedef struct
     int     GlobalButtonMapping[8][4] = {{0,0,0,0}, {0,0,0,0}, {0,0,0,0}, {0,0,0,0}, {0,0,0,0}, {0,0,0,0}};  
     int     ButtonMapping[8][4] = {{0,0,0,0}, {0,0,0,0}, {0,0,0,0}, {0,0,0,0}, {0,0,0,0}, {0,0,0,0}};  
 
+    ::ButtonMapping<1> ButtonHotkeyOpenMenu; // Stores button that can be held to open the menu.
+
     ::ButtonMapping<1> ButtonHotkeyDisableFramelimit; // Stores button that can be held to disable the frame limit.
 
     bool    Changed = false;                // Stores whether the configuration has been changed and should be written.


### PR DESCRIPTION
I'm not super happy with how the frame limiter override is implemented but it works, meh.

Playing some JRPGs on 3DS with hotkey to quadruple the framerate is pretty nice, really.