### PR TITLE
Option to framelimit by 3DS screen refresh rate (VBlank).

### DIFF
--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -379,6 +379,7 @@ std::vector<SMenuItem> makeOptionsForFrameRate() {
     AddMenuDialogOption(items, static_cast<int>(EmulatedFramerate::UseRomRegion), "Default based on ROM region"s, ""s);
     AddMenuDialogOption(items, static_cast<int>(EmulatedFramerate::ForceFps50),   "50 FPS"s,                      ""s);
     AddMenuDialogOption(items, static_cast<int>(EmulatedFramerate::ForceFps60),   "60 FPS"s,                      ""s);
+    AddMenuDialogOption(items, static_cast<int>(EmulatedFramerate::Match3DS),     "Match 3DS refresh rate"s,      ""s);
     return items;
 };
 
@@ -1409,7 +1410,11 @@ void emulatorLoop()
                 snesFrameTotalAccurateTicks = 0;
                 snesFramesSkipped = 0;
 
-                svcSleepThread ((long)(timeDiffInMilliseconds * 1000));
+                if (settings3DS.ForceFrameRate == EmulatedFramerate::Match3DS) {
+                    gspWaitForVBlank();
+                } else {
+                    svcSleepThread ((long)(timeDiffInMilliseconds * 1000));
+                }
 
                 skipDrawingFrame = false;
             }

--- a/source/3dsmain.cpp
+++ b/source/3dsmain.cpp
@@ -376,9 +376,9 @@ std::vector<SMenuItem> makeOptionsForFrameskip() {
 
 std::vector<SMenuItem> makeOptionsForFrameRate() {
     std::vector<SMenuItem> items;
-    AddMenuDialogOption(items, 0, "Default based on ROM region"s,    ""s);
-    AddMenuDialogOption(items, 1, "50 FPS"s,                  ""s);
-    AddMenuDialogOption(items, 2, "60 FPS"s,                  ""s);
+    AddMenuDialogOption(items, static_cast<int>(EmulatedFramerate::UseRomRegion), "Default based on ROM region"s, ""s);
+    AddMenuDialogOption(items, static_cast<int>(EmulatedFramerate::ForceFps50),   "50 FPS"s,                      ""s);
+    AddMenuDialogOption(items, static_cast<int>(EmulatedFramerate::ForceFps60),   "60 FPS"s,                      ""s);
     return items;
 };
 
@@ -425,8 +425,8 @@ std::vector<SMenuItem> makeOptionMenu() {
     AddMenuHeader2(items, "Graphics"s);
     AddMenuPicker(items, "  Frameskip"s, "Try changing this if the game runs slow. Skipping frames helps it run faster, but less smooth."s, makeOptionsForFrameskip(), settings3DS.MaxFrameSkips, DIALOGCOLOR_CYAN, true,
                   []( int val ) { CheckAndUpdate( settings3DS.MaxFrameSkips, val, settings3DS.Changed ); });
-    AddMenuPicker(items, "  Framerate"s, "Some games run at 50 or 60 FPS by default. Override if required."s, makeOptionsForFrameRate(), settings3DS.ForceFrameRate, DIALOGCOLOR_CYAN, true,
-                  []( int val ) { CheckAndUpdate( settings3DS.ForceFrameRate, val, settings3DS.Changed ); });
+    AddMenuPicker(items, "  Framerate"s, "Some games run at 50 or 60 FPS by default. Override if required."s, makeOptionsForFrameRate(), static_cast<int>(settings3DS.ForceFrameRate), DIALOGCOLOR_CYAN, true,
+                  []( int val ) { CheckAndUpdate( settings3DS.ForceFrameRate, static_cast<EmulatedFramerate>(val), settings3DS.Changed ); });
     AddMenuPicker(items, "  In-Frame Palette Changes"s, "Try changing this if some colours in the game look off."s, makeOptionsForInFramePaletteChanges(), settings3DS.PaletteFix, DIALOGCOLOR_CYAN, true,
                   []( int val ) { CheckAndUpdate( settings3DS.PaletteFix, val, settings3DS.Changed ); });
     AddMenuDisabledOption(items, ""s);
@@ -577,11 +577,11 @@ bool settingsUpdateAllSettings(bool updateGameSettings = true)
         else
             settings3DS.TicksPerFrame = TICKS_PER_FRAME_NTSC;
 
-        if (settings3DS.ForceFrameRate == 1)
+        if (settings3DS.ForceFrameRate == EmulatedFramerate::ForceFps50) {
             settings3DS.TicksPerFrame = TICKS_PER_FRAME_PAL;
-
-        else if (settings3DS.ForceFrameRate == 2)
+        } else if (settings3DS.ForceFrameRate == EmulatedFramerate::ForceFps60) {
             settings3DS.TicksPerFrame = TICKS_PER_FRAME_NTSC;
+        }
 
         // update global volume
         //
@@ -669,7 +669,9 @@ bool settingsReadWriteFullListByGame(bool writeMode)
     config3dsReadWriteInt32("# Do not modify this file or risk losing your settings.\n", NULL, 0, 0);
 
     config3dsReadWriteInt32("Frameskips=%d\n", &settings3DS.MaxFrameSkips, 0, 4);
-    config3dsReadWriteInt32("Framerate=%d\n", &settings3DS.ForceFrameRate, 0, 2);
+    int tmp = static_cast<int>(settings3DS.ForceFrameRate);
+    config3dsReadWriteInt32("Framerate=%d\n", &tmp, 0, static_cast<int>(EmulatedFramerate::Count) - 1);
+    settings3DS.ForceFrameRate = static_cast<EmulatedFramerate>(tmp);
     config3dsReadWriteInt32("TurboA=%d\n", &settings3DS.Turbo[0], 0, 1);
     config3dsReadWriteInt32("TurboB=%d\n", &settings3DS.Turbo[1], 0, 1);
     config3dsReadWriteInt32("TurboX=%d\n", &settings3DS.Turbo[2], 0, 1);
@@ -771,7 +773,7 @@ bool settingsLoad(bool includeGameSettings = true)
             // set in the previous game.
             //
             settings3DS.MaxFrameSkips = 1;
-            settings3DS.ForceFrameRate = 0;
+            settings3DS.ForceFrameRate = EmulatedFramerate::UseRomRegion;
             settings3DS.Volume = 4;
 
             for (int i = 0; i < 6; i++)     // and clear all turbo buttons.

--- a/source/3dssettings.h
+++ b/source/3dssettings.h
@@ -4,7 +4,8 @@ enum class EmulatedFramerate {
     UseRomRegion = 0,
     ForceFps50 = 1,
     ForceFps60 = 2,
-    Count = 3
+    Match3DS = 3,
+    Count = 4
 };
 
 enum class SnesButtons {

--- a/source/3dssettings.h
+++ b/source/3dssettings.h
@@ -1,5 +1,12 @@
 #include <array>
 
+enum class EmulatedFramerate {
+    UseRomRegion = 0,
+    ForceFps50 = 1,
+    ForceFps60 = 2,
+    Count = 3
+};
+
 enum class SnesButtons {
     A      =  0,
     B      =  1,
@@ -66,7 +73,7 @@ typedef struct
     int     Font = 0;                       // 0 - Tempesta, 1 - Ronda, 2 - Arial
     int     ScreenStretch = 0;              // 0 - no stretch, 1 - stretch full, 2 - aspect fit
 
-    int     ForceFrameRate = 0;             // 0 - Use ROM's Region, 1 - Force 50 fps, 2 - Force 60 fps
+    EmulatedFramerate ForceFrameRate = EmulatedFramerate::UseRomRegion;
 
     int     StretchWidth, StretchHeight;
     int     CropPixels;


### PR DESCRIPTION
This option tries to render/process exactly one SNES frame per 3DS screen refresh (which appears to be something like 59.834 Hz). This is not accurate to the speed of the original hardware (which is somewhere around 60.08 Hz depending on who you ask) or the speed of the original video signal (60000/1001, or 59.94 Hz), but can feel smoother in some games -- the one game I definitely notice less stuttering in is Yoshi's Island -- and the speed difference is small enough where you probably don't actually notice that it's ever so slightly slower.

This doesn't seem to be entirely perfect though, I'm not really sure why. This is hard to measure without having a direct frame-perfect video capture.