### PR TITLE
Fix Makefile for broken merge commit 412110e61220a9d95d41b87053926866df7115a0.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ BUILD		:=	build
 SOURCES		:=	source
 DATA		:=	data
 INCLUDES	:=	include
-#ROMFS		:=	romfs
+ROMFS		:=	romfs
 
 #---------------------------------------------------------------------------------
 # options for code generation


### PR DESCRIPTION
Not entirely sure what happened here, but the romfs changes to the Makefile were silently dropped by 412110e61220a9d95d41b87053926866df7115a0 as noticed by Asdolo in the discussions for 70aba6495333ce964e3fd3e30c1f70e6885b1d97. This fixes this.